### PR TITLE
[Enhancement] disable static map property

### DIFF
--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -310,6 +310,7 @@ export class ExportVideoPanelContainer extends Component {
       header,
       deckProps,
       staticMapProps,
+      disableStaticMap,
       mapboxLayerBeforeId
     } = this.props;
     const {
@@ -357,6 +358,7 @@ export class ExportVideoPanelContainer extends Component {
         setViewState={this.setViewState}
         deckProps={deckProps}
         staticMapProps={staticMapProps}
+        disableStaticMap={disableStaticMap}
         mapboxLayerBeforeId={mapboxLayerBeforeId}
         // Settings Props
         settings={settings}
@@ -377,5 +379,6 @@ ExportVideoPanelContainer.defaultProps = {
   header: true,
   glContext: undefined,
   deckProps: {},
-  staticMapProps: {}
+  staticMapProps: {},
+  disableStaticMap: false
 };

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -62,8 +62,7 @@ export class ExportVideoPanelPreview extends Component {
   }
 
   _resizeVideo() {
-    const {exportVideoWidth, resolution, staticMapProps} = this.props;
-    const {disableStaticMap} = staticMapProps;
+    const {exportVideoWidth, resolution, disableStaticMap} = this.props;
 
     this._setDevicePixelRatio(resolution[0] / exportVideoWidth);
 
@@ -146,9 +145,9 @@ export class ExportVideoPanelPreview extends Component {
       durationMs,
       resolution,
       deckProps,
-      staticMapProps
+      staticMapProps,
+      disableStaticMap
     } = this.props;
-    const {disableStaticMap} = staticMapProps;
     const {glContext, mapStyle} = this.state;
     const deck = this.deckRef.current && this.deckRef.current.deck;
 

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -67,7 +67,6 @@ export class ExportVideoPanelPreview extends Component {
     this._setDevicePixelRatio(resolution[0] / exportVideoWidth);
 
     if (disableStaticMap) {
-      // ! deck resize???? just by device pixels ratio?
       return;
     }
 
@@ -133,7 +132,7 @@ export class ExportVideoPanelPreview extends Component {
       map.addLayer(new MapboxLayer({id: keplerLayers[i].id, deck}), beforeId);
     }
 
-    map.on('render', () => this._onAfterRender());
+    map.on('render', this._onAfterRender);
   }
 
   render() {

--- a/modules/react/src/components/export-video/export-video-panel.js
+++ b/modules/react/src/components/export-video/export-video-panel.js
@@ -65,6 +65,7 @@ const PanelBody = ({
   rendering,
   deckProps,
   staticMapProps,
+  disableStaticMap,
   mapboxLayerBeforeId
 }) => (
   <PanelBodyInner className="export-video-panel__body" exportVideoWidth={exportVideoWidth}>
@@ -79,6 +80,7 @@ const PanelBody = ({
       durationMs={settings.durationMs}
       deckProps={deckProps}
       staticMapProps={staticMapProps}
+      disableStaticMap={disableStaticMap}
       mapboxLayerBeforeId={mapboxLayerBeforeId}
     />
     <ExportVideoPanelSettings settings={settings} resolution={resolution} />
@@ -111,7 +113,8 @@ const ExportVideoPanel = ({
   rendering,
   previewing,
   deckProps,
-  staticMapProps
+  staticMapProps,
+  disableStaticMap
 }) => {
   return (
     <Panel exportVideoWidth={exportVideoWidth} className="export-video-panel">
@@ -132,6 +135,7 @@ const ExportVideoPanel = ({
         rendering={rendering}
         deckProps={deckProps}
         staticMapProps={staticMapProps}
+        disableStaticMap={disableStaticMap}
         mapboxLayerBeforeId={mapboxLayerBeforeId}
       />
       <ExportVideoPanelFooter


### PR DESCRIPTION
- added **disableStaticMap** property for ExportVideoPanelPreview. The property prevents the creation of MapboxLayers from passed layers and can be useful for capturing layers that don't use web-mercator projection.