### PR TITLE
[chore] remove hover highlight in video export modal

### DIFF
--- a/modules/react/src/kepler-layers.js
+++ b/modules/react/src/kepler-layers.js
@@ -52,16 +52,18 @@ function renderLayer(overlays, idx, map, viewState) {
   };
 
   // Layer is Layer class
-  const layerOverlay = layer.renderLayer({
-    data,
-    gpuFilter,
-    idx,
-    interactionConfig,
-    layerCallbacks,
-    mapState: {...mapState, ...viewState},
-    animationConfig,
-    objectHovered
-  });
+  const layerOverlay = layer
+    .renderLayer({
+      data,
+      gpuFilter,
+      idx,
+      interactionConfig,
+      layerCallbacks,
+      mapState: {...mapState, ...viewState},
+      animationConfig,
+      objectHovered
+    })
+    .map(deckLayer => deckLayer.clone({pickable: false}));
   return overlays.concat(layerOverlay || []);
 }
 


### PR DESCRIPTION
The yellow on-hover highlights were visible in video exports if the mouse was in the map. This is not intended behavior.