### PR TITLE
feat(deck adapter) wait for async layers to load

### DIFF
--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -127,7 +127,8 @@ export default class DeckAdapter {
    * @param {(nextTimeMs: number) => void} proceedToNextFrame
    */
   onAfterRender(proceedToNextFrame) {
-    if (this.videoCapture.isRecording()) {
+    const areAllLayersLoaded = this.deck.props.layers.every(layer => layer.isLoaded);
+    if (this.videoCapture.isRecording() && areAllLayersLoaded) {
       this.videoCapture.capture(this.deck.canvas, nextTimeMs => {
         this.seek({timeMs: nextTimeMs});
         proceedToNextFrame(nextTimeMs);


### PR DESCRIPTION
Currently the render handler on a hubble/deck adapter (`adapter.onAfterRender`) is expected to be called after every deck.gl render update (`deck.onAfterRender`), or if using mapbox/deck integration, on every map render event [0]. Our testing suggests a render update occurs every time a layer's data updates (including any internal asynchronous data update, such as tile loading). So, hubble can wait until the render update call where all deck layers are loaded, and then capture the frame.

**Changelog**
The current Hubble implementation can already wait for a number of internal flags before progressing the animation manager to the next frame, so we can add one more. 

After this PR, the "wait" flags will be:

1. Is hubble currently supposed to be recording? 
    - flag `true` when `adapter.render()` is called until either `adapter.stop()` interrupts a recording, or a recording reaches the `timecode.end` frame. Whichever happens first.

2. **[New flag] Is all deck data loaded?** 
    - See https://github.com/visgl/deck.gl/issues/6145

3. Is hubble already capturing a frame? 
    - frame encoding is asynchronous, so will be flag `true` until this promise resolves.

**Demo**
Before: Notice the black artifacts where data isn't loaded, and the black frames around second 7.
https://user-images.githubusercontent.com/2461547/133699300-3eee00fc-4b2c-4566-93c5-b426ddfe9c85.mp4

After: No artifacts or skipped frames. A frame is only captured when all deck layers are loaded. 🎉
https://user-images.githubusercontent.com/2461547/133700971-99c2d225-f592-452b-9bd2-9aa3213745c6.mp4

Note: These videos are exported with the webm encoder and locally recompressed with ffmpeg.
`ffmpeg -i after_deck_loaded.webm -vcodec libx264 -crf 23 -pix_fmt yuv420p -tune animation after_deck_loaded.mp4`

[0] Look for: `map.on('render', () => {adapter.onAfterRender(...)})`. In this PR only the deck render update will be addressed, and mapbox will need further investigation. 