### PR TITLE
fix(kepler) blank layer when no deck layers

### DIFF
--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -127,10 +127,10 @@ export class ExportVideoPanelPreview extends Component {
     const keplerLayers = this.createLayers();
     const beforeId = this.props.mapboxLayerBeforeId;
 
-    // If there aren't any layers, combine map and deck with a fake layer. 
-    if (!keplerLayers.length) { 
-      map.addLayer(new MapboxLayer({id: '%%blank-layer', deck})); 
-    } 
+    // If there aren't any layers, combine map and deck with a fake layer.
+    if (!keplerLayers.length) {
+      map.addLayer(new MapboxLayer({id: '%%blank-layer', deck}));
+    }
 
     for (let i = 0; i < keplerLayers.length; i++) {
       // Adds DeckGL layers to Mapbox so Mapbox can be the bottom layer. Removing this clips DeckGL layers

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -127,6 +127,11 @@ export class ExportVideoPanelPreview extends Component {
     const keplerLayers = this.createLayers();
     const beforeId = this.props.mapboxLayerBeforeId;
 
+    // If there aren't any layers, combine map and deck with a fake layer. 
+    if (!keplerLayers.length) { 
+      map.addLayer(new MapboxLayer({id: '%%blank-layer', deck})); 
+    } 
+
     for (let i = 0; i < keplerLayers.length; i++) {
       // Adds DeckGL layers to Mapbox so Mapbox can be the bottom layer. Removing this clips DeckGL layers
       map.addLayer(new MapboxLayer({id: keplerLayers[i].id, deck}), beforeId);


### PR DESCRIPTION
For #157.

Test
- Open kepler-integration example, delete all layers, attempt to export video.
- Also should work when all layers are just "unseen"