### PR TITLE
add(examples) support for local luma.gl development

### DIFF
--- a/examples/camera/package.json
+++ b/examples/camera/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start-local-luma": "webpack-dev-server --env.local --env.local-luma --progress --hot --open",
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },

--- a/examples/camera/webpack.config.js
+++ b/examples/camera/webpack.config.js
@@ -1,7 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
-const config = {
+const CONFIG = {
   mode: 'development',
 
   entry: {
@@ -35,4 +35,5 @@ const config = {
   ]
 };
 
-module.exports = env => (env && env.local ? require('../webpack.config.local')(config) : config);
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);

--- a/examples/kepler-integration/package.json
+++ b/examples/kepler-integration/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start-local-luma": "webpack-dev-server --env.local --env.local-luma --progress --hot --open",
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },

--- a/examples/kepler-integration/webpack.config.js
+++ b/examples/kepler-integration/webpack.config.js
@@ -2,7 +2,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 const resolve = require('path').resolve;
 
-const config = {
+const CONFIG = {
   mode: 'development',
 
   entry: {
@@ -43,4 +43,5 @@ const config = {
   ]
 };
 
-module.exports = env => (env && env.local ? require('../webpack.config.local')(config) : config);
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);

--- a/examples/quick-start/package.json
+++ b/examples/quick-start/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start-local-luma": "webpack-dev-server --env.local --env.local-luma --progress --hot --open",
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },

--- a/examples/quick-start/webpack.config.js
+++ b/examples/quick-start/webpack.config.js
@@ -1,7 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
-const config = {
+const CONFIG = {
   mode: 'development',
 
   entry: {
@@ -35,4 +35,5 @@ const config = {
   ]
 };
 
-module.exports = env => (env && env.local ? require('../webpack.config.local')(config) : config);
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);

--- a/examples/terrain/package.json
+++ b/examples/terrain/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start-local-luma": "webpack-dev-server --env.local --env.local-luma --progress --hot --open",
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },

--- a/examples/terrain/webpack.config.js
+++ b/examples/terrain/webpack.config.js
@@ -1,7 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
-const config = {
+const CONFIG = {
   mode: 'development',
 
   entry: {
@@ -35,4 +35,5 @@ const config = {
   ]
 };
 
-module.exports = env => (env && env.local ? require('../webpack.config.local')(config) : config);
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);

--- a/examples/trips/package.json
+++ b/examples/trips/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start-local-luma": "webpack-dev-server --env.local --env.local-luma --progress --hot --open",
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },

--- a/examples/trips/webpack.config.js
+++ b/examples/trips/webpack.config.js
@@ -1,7 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
-const config = {
+const CONFIG = {
   mode: 'development',
 
   entry: {
@@ -35,4 +35,5 @@ const config = {
   ]
 };
 
-module.exports = env => (env && env.local ? require('../webpack.config.local')(config) : config);
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -93,18 +93,31 @@ function makeLocalDevConfig(EXAMPLE_DIR = LIB_DIR, linkToLuma, linkToMath) {
           test: /\.js$/,
           use: ['source-map-loader'],
           enforce: 'pre'
+        },
+        {
+          // Compile source using babel. This is not necessary for src to run in the browser
+          // However class inheritance cannot happen between transpiled/non-transpiled code
+          // Which affects some examples
+          test: /\.js$/,
+          loader: 'babel-loader',
+          options: {
+            plugins: [
+              '@babel/plugin-proposal-class-properties',
+              [
+                '@babel/plugin-transform-runtime',
+                {
+                  absoluteRuntime: false,
+                  corejs: false,
+                  helpers: false,
+                  regenerator: true,
+                  useESModules: false
+                }
+              ]
+            ],
+            presets: [['@babel/preset-env', {targets: '> 1%, not ie 11'}], '@babel/preset-react']
+          },
+          include: [resolve(ROOT_DIR, 'modules'), resolve(ROOT_DIR, '../luma.gl/modules')]
         }
-        // {
-        //   // Compile source using babel. This is not necessary for src to run in the browser
-        //   // However class inheritance cannot happen between transpiled/non-transpiled code
-        //   // Which affects some examples
-        //   test: /\.js$/,
-        //   loader: 'babel-loader',
-        //   options: {
-        //     presets: [['@babel/preset-env', {targets: '> 1%, not ie 11'}], '@babel/preset-react']
-        //   },
-        //   include: [resolve(ROOT_DIR, 'modules'), resolve(ROOT_DIR, '../luma.gl/modules')]
-        // }
       ]
     }
   };

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -8,43 +8,141 @@ const {resolve} = require('path');
 const ALIASES = require('ocular-dev-tools/config/ocular.config')({
   root: resolve(__dirname, '..')
 }).aliases;
+const ROOT_DIR = resolve(__dirname, '..');
+const LIB_DIR = resolve(__dirname, '..');
 
-// Support for hot reloading changes
-const LOCAL_DEVELOPMENT_CONFIG = {
-  // suppress warnings about bundle size
-  devServer: {
-    stats: {
-      warnings: false
+// Support for hot reloading changes to the deck.gl library:
+function makeLocalDevConfig(EXAMPLE_DIR = LIB_DIR, linkToLuma, linkToMath) {
+  const LUMA_LINK_ALIASES = {
+    '@luma.gl/constants': `${ROOT_DIR}/../luma.gl/modules/constants/src`,
+    '@luma.gl/core': `${ROOT_DIR}/../luma.gl/modules/core/src`,
+    '@luma.gl/debug': `${ROOT_DIR}/../luma.gl/modules/debug/src`,
+    '@luma.gl/engine': `${ROOT_DIR}/../luma.gl/modules/engine/src`,
+    '@luma.gl/webgl': `${ROOT_DIR}/../luma.gl/modules/webgl/src`,
+    '@luma.gl/gltools': `${ROOT_DIR}/../luma.gl/modules/gltools/src`,
+    '@luma.gl/shadertools': `${ROOT_DIR}/../luma.gl/modules/shadertools/src`,
+    '@luma.gl/experimental': `${ROOT_DIR}/../luma.gl/modules/experimental/src`
+  };
+  const LUMA_LOCAL_ALIASES = {
+    '@luma.gl/constants': `${ROOT_DIR}/node_modules/@luma.gl/constants`,
+    '@luma.gl/core': `${ROOT_DIR}/node_modules/@luma.gl/core`,
+    '@luma.gl/engine': `${ROOT_DIR}/node_modules/@luma.gl/engine`,
+    '@luma.gl/webgl': `${ROOT_DIR}/node_modules/@luma.gl/webgl`,
+    '@luma.gl/gltools': `${ROOT_DIR}/node_modules/@luma.gl/gltools`,
+    '@luma.gl/shadertools': `${ROOT_DIR}/node_modules/@luma.gl/shadertools`,
+    '@luma.gl/experimental': `${ROOT_DIR}/node_modules/@luma.gl/experimental`,
+    // @luma.gl/experimental is not available in the root node_modules, must be imported
+    // where required.
+    '@loaders.gl/core': `${ROOT_DIR}/node_modules/@loaders.gl/core`,
+    '@loaders.gl/images': `${ROOT_DIR}/node_modules/@loaders.gl/images`
+  };
+
+  const LUMA_ALIASES = linkToLuma ? LUMA_LINK_ALIASES : LUMA_LOCAL_ALIASES;
+  // console.warn(JSON.stringify(LUMA_ALIASES, null, 2)); // uncomment to debug config
+  // require('fs').writeFileSync('/tmp/ocular.log', JSON.stringify(config, null, 2));
+
+  const MATH_ALIASES = {};
+  if (linkToMath) {
+    const MATH_MODULES = [
+      'core',
+      'culling',
+      'geoid',
+      'geospatial',
+      'main',
+      'web-mercator',
+      'polygon',
+      'proj4',
+      'sun',
+      'web'
+    ];
+    for (const module of MATH_MODULES) {
+      MATH_ALIASES[`@math.gl/${module}`] = `${ROOT_DIR}/../math.gl/modules/${module}/src`;
     }
-  },
-
-  devtool: 'source-map',
-
-  resolve: {
-    alias: Object.assign({}, ALIASES)
-  },
-
-  module: {
-    rules: [
-      {
-        // Unfortunately, webpack doesn't import library sourcemaps on its own...
-        test: /\.js$/,
-        use: ['source-map-loader'],
-        enforce: 'pre'
-      }
-    ]
+  } else {
+    MATH_ALIASES['math.gl'] = resolve(LIB_DIR, './node_modules/math.gl');
   }
-};
 
-module.exports = config => {
-  config.resolve = config.resolve || {};
-  config.resolve.alias = Object.assign(
-    {},
-    config.resolve.alias,
-    LOCAL_DEVELOPMENT_CONFIG.resolve.alias
-  );
+  return {
+    // TODO - Uncomment when all examples use webpack 4 for faster bundling
+    // mode: 'development',
 
-  config.module.rules = config.module.rules.concat(LOCAL_DEVELOPMENT_CONFIG.module.rules);
-  config.devtool = LOCAL_DEVELOPMENT_CONFIG.devtool;
+    // suppress warnings about bundle size
+    devServer: {
+      stats: {
+        warnings: false
+      }
+    },
+
+    devtool: 'source-map',
+
+    resolve: {
+      // mainFields: ['esnext', 'module', 'main'],
+
+      alias: Object.assign({}, ALIASES, LUMA_ALIASES, MATH_ALIASES, {
+        // Use luma.gl installed in parallel with deck.gl
+        // Important: ensure shared dependencies come from the main node_modules dir
+        // Versions will be controlled by the deck.gl top level package.json
+        'viewport-mercator-project': resolve(LIB_DIR, './node_modules/viewport-mercator-project'),
+        react: resolve(LIB_DIR, './node_modules/react')
+      })
+    },
+    module: {
+      rules: [
+        {
+          // Unfortunately, webpack doesn't import library sourcemaps on its own...
+          test: /\.js$/,
+          use: ['source-map-loader'],
+          enforce: 'pre'
+        }
+        // {
+        //   // Compile source using babel. This is not necessary for src to run in the browser
+        //   // However class inheritance cannot happen between transpiled/non-transpiled code
+        //   // Which affects some examples
+        //   test: /\.js$/,
+        //   loader: 'babel-loader',
+        //   options: {
+        //     presets: [['@babel/preset-env', {targets: '> 1%, not ie 11'}], '@babel/preset-react']
+        //   },
+        //   include: [resolve(ROOT_DIR, 'modules'), resolve(ROOT_DIR, '../luma.gl/modules')]
+        // }
+      ]
+    }
+  };
+}
+
+function addLocalDevSettings(config, exampleDir, linkToLuma, linkToMath) {
+  const LOCAL_DEV_CONFIG = makeLocalDevConfig(exampleDir, linkToLuma, linkToMath);
+  config = Object.assign({}, LOCAL_DEV_CONFIG, config);
+  config.resolve = Object.assign({}, LOCAL_DEV_CONFIG.resolve, config.resolve || {});
+  config.resolve.alias = config.resolve.alias || {};
+  Object.assign(config.resolve.alias, LOCAL_DEV_CONFIG.resolve.alias);
+
+  config.module = config.module || {};
+  Object.assign(config.module, {
+    rules: (config.module.rules || []).concat(LOCAL_DEV_CONFIG.module.rules)
+  });
+  return config;
+}
+
+module.exports = (config, exampleDir) => env => {
+  // npm run start-local now transpiles the lib
+  if (!env) {
+    return config;
+  }
+
+  if (env.local) {
+    config = addLocalDevSettings(config, exampleDir, env['local-luma'], env['local-math']);
+  }
+
+  // npm run start-es6 does not transpile the lib
+  if (env && env.es6) {
+    config = addLocalDevSettings(config, exampleDir, env['local-luma'], env['local-math']);
+  }
+
+  if (env && env.production) {
+    config.mode = 'production';
+  }
+
+  // console.warn(JSON.stringify(config, null, 2)); // uncomment to debug config
   return config;
 };

--- a/examples/worldview/package.json
+++ b/examples/worldview/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start-local-luma": "webpack-dev-server --env.local --env.local-luma --progress --hot --open",
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },

--- a/examples/worldview/webpack.config.js
+++ b/examples/worldview/webpack.config.js
@@ -2,7 +2,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 const resolve = require('path').resolve;
 
-const config = {
+const CONFIG = {
   mode: 'development',
 
   entry: {
@@ -55,4 +55,5 @@ const config = {
   ]
 };
 
-module.exports = env => (env && env.local ? require('../webpack.config.local')(config) : config);
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);


### PR DESCRIPTION
Supporting #160 and #159.

To use, run an example with `yarn start-local-luma` and install luma.gl for local development adjacent to the hubble repo.

```
code/
  hubble.gl/
  luma.gl/
```