### PR TITLE
add(examples) sf trees animation

### DIFF
--- a/examples/worldview/src/features/kepler/hooks.js
+++ b/examples/worldview/src/features/kepler/hooks.js
@@ -21,7 +21,14 @@ import {KeplerAnimation} from '@hubble.gl/core';
 import {createKeplerLayers} from '@hubble.gl/react';
 import {viewStateSelector} from '../map/mapSlice';
 
-export const useKepler = ({mapId, fetchMap, filterKeyframes, layerKeyframes, tripKeyframe}) => {
+export const useKepler = ({
+  mapId,
+  fetchMap,
+  filterKeyframes,
+  layerKeyframes,
+  tripKeyframe,
+  cameraKeyframe
+}) => {
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch((_, getState) => {
@@ -53,6 +60,7 @@ export const useKepler = ({mapId, fetchMap, filterKeyframes, layerKeyframes, tri
           filterKeyframes,
           animationConfig,
           tripKeyframe,
+          cameraKeyframe,
           onTripFrameUpdate: time => dispatch(setLayerAnimationTime(time)),
           onFilterFrameUpdate: (idx, prop, value) => dispatch(setFilter(idx, prop, value)),
           onLayerFrameUpdate: (layer, visConfig) =>

--- a/examples/worldview/src/scenes/newYork/index.js
+++ b/examples/worldview/src/scenes/newYork/index.js
@@ -1,6 +1,5 @@
 import {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import {useAfterKepler} from '../../app';
 import {useKeplerMapState, useKepler} from '../../features/kepler/hooks';
 import {loadSampleData} from './data';
 import {
@@ -22,17 +21,7 @@ export const useScene = () => {
   const duration = useSelector(durationSelector);
   const adapter = useSelector(adapterSelector);
 
-  useKepler({
-    mapId: KEPLER_MAP_ID,
-    fetchMap: async () => {
-      const actions = loadSampleData();
-      actions.forEach(a => dispatch(a));
-    }
-  });
-
-  const newYorkScene = () => {
-    // load sample data
-
+  useEffect(() => {
     dispatch(timecodeChange({start: 0, end: 5000, framerate: 30}));
     dispatch(resolutionChange('1920x1080'));
     dispatch(
@@ -46,7 +35,15 @@ export const useScene = () => {
       })
     );
     dispatch(formatChange('gif'));
-  };
+  }, []);
+
+  useKepler({
+    mapId: KEPLER_MAP_ID,
+    fetchMap: async () => {
+      const actions = loadSampleData();
+      actions.forEach(a => dispatch(a));
+    }
+  });
 
   useEffect(() => {
     if (viewState) {
@@ -64,6 +61,5 @@ export const useScene = () => {
     }
   }, [Boolean(viewState), duration]);
 
-  useAfterKepler(newYorkScene);
   useKeplerMapState('map');
 };

--- a/examples/worldview/src/scenes/sftrees/index.js
+++ b/examples/worldview/src/scenes/sftrees/index.js
@@ -6,9 +6,10 @@ import {
   formatChange,
   formatConfigsChange
 } from '../../features/renderer';
-import {useAfterKepler} from '../../app';
 import {useKepler, loadKeplerJson} from '../../features/kepler';
 import {updateViewState} from '../../features/map';
+import {useEffect} from 'react';
+import {easing} from 'popmotion';
 
 // const SF = {"latitude":37.75996553215378,"longitude":-122.43586511157562,"zoom":12.29897059083749,"bearing":0,"pitch":0}
 const SF = {
@@ -29,17 +30,22 @@ export const useScene = () => {
         dispatch(action);
         dispatch(updateViewState(SF));
       });
-    }
+    },
     // filterKeyframes: [],
     // layerKeyframes: [],
-    // tripKeyframe: {}
+    // tripKeyframe: {},
+    cameraKeyframe: {
+      timings: [500, 3500],
+      keyframes: [SF, {...SF, pitch: 0, zoom: SF.zoom - 3}],
+      easings: [easing.easeInOut]
+    }
   });
 
-  const scene = () => {
+  useEffect(() => {
     dispatch(
       timecodeChange({
         start: 0,
-        end: 7500,
+        end: 4000,
         framerate: 60
       })
     );
@@ -55,9 +61,8 @@ export const useScene = () => {
         }
       })
     );
-    dispatch(formatChange('png'));
-  };
+    dispatch(formatChange('webm'));
+  }, []);
 
-  useAfterKepler(scene);
   return [];
 };


### PR DESCRIPTION
Adding a camera animation to the sftrees demo, and passing `cameraKeyframe` through the `useKepler` hook.