### PR TITLE
add(worldview) resolution debugger overlay and test resolutions

### DIFF
--- a/examples/worldview/src/features/map/DebugOverlay.js
+++ b/examples/worldview/src/features/map/DebugOverlay.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
+/* eslint-disable complexity */
 export function DebugOverlay({containerRef, deckRef, dimension, previewSize, dpi, onDpiChange}) {
-  const container = containerRef.current;
+  const container = containerRef && containerRef.current;
   const deck = deckRef.current;
   const canvas = deck && deck._canvasRef.current;
   const canvasRect = canvas && canvas.getBoundingClientRect();
@@ -44,7 +45,7 @@ export function DebugOverlay({containerRef, deckRef, dimension, previewSize, dpi
       <div>
         pixel ratio: <b>{window.devicePixelRatio}</b>
       </div>
-      {canvas && (
+      {canvas && isFinite(window.devicePixelRatio) && (
         <div>
           luma size pre-flooring: <b>{window.devicePixelRatio * canvas.clientWidth}</b>px x{' '}
           <b>{window.devicePixelRatio * canvas.clientHeight}</b>px

--- a/examples/worldview/src/features/map/DebugOverlay.js
+++ b/examples/worldview/src/features/map/DebugOverlay.js
@@ -1,0 +1,65 @@
+import React from 'react';
+
+export function DebugOverlay({containerRef, deckRef, dimension, previewSize, dpi, onDpiChange}) {
+  const container = containerRef.current;
+  const deck = deckRef.current;
+  const canvas = deck && deck._canvasRef.current;
+  const canvasRect = canvas && canvas.getBoundingClientRect();
+  const gl = deck && deck.deck.animationLoop && deck.deck.animationLoop.gl;
+
+  return (
+    <div style={{position: 'absolute', top: 0, left: 0, color: 'white'}}>
+      <div>
+        Expected Export size: <b>{dimension.width}</b>px x <b>{dimension.height}</b>px
+      </div>
+      <div>
+        Expected Container size: <b>{previewSize.width}</b>px x <b>{previewSize.height}</b>px
+      </div>
+      {container && (
+        <div>
+          Container CSS client size: <b>{container.clientWidth}</b>px x{' '}
+          <b>{container.clientHeight}</b>px
+        </div>
+      )}
+      {canvasRect && (
+        <div>
+          Canvas BoundingClientRect size: <b>{canvasRect.width}</b>px x <b>{canvasRect.height}</b>px
+        </div>
+      )}
+      {canvas && (
+        <div>
+          Canvas CSS size: <b>{canvas.clientWidth}</b>px x <b>{canvas.clientHeight}</b>px
+        </div>
+      )}
+      {canvas && (
+        <div>
+          Canvas internal size: <b>{canvas.width}</b>px x <b>{canvas.height}</b>px
+        </div>
+      )}
+      {gl && (
+        <div>
+          GL draw buffer size: <b>{gl.drawingBufferWidth}</b>px x <b>{gl.drawingBufferHeight}</b>px
+        </div>
+      )}
+      <div>
+        pixel ratio: <b>{window.devicePixelRatio}</b>
+      </div>
+      {canvas && (
+        <div>
+          luma size pre-flooring: <b>{window.devicePixelRatio * canvas.clientWidth}</b>px x{' '}
+          <b>{window.devicePixelRatio * canvas.clientHeight}</b>px
+        </div>
+      )}
+      <div>
+        <input
+          type="range"
+          min={0.01}
+          max={10.0}
+          step={0.01}
+          value={dpi}
+          onChange={e => onDpiChange(parseFloat(e.target.value))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -131,7 +131,7 @@ export class Map extends Component {
       dimension,
       debug
     } = this.props;
-    const {glContext, dpi} = this.state;
+    const {glContext} = this.state;
     const deck = this.deckRef.current && this.deckRef.current.deck;
 
     const deckStyle = {
@@ -176,8 +176,6 @@ export class Map extends Component {
             containerRef={this.containerRef}
             dimension={dimension}
             previewSize={{width, height}}
-            dpi={dpi}
-            onDpiChange={this._changeDpi}
           />
         )}
       </div>

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -24,6 +24,7 @@ import {StaticMap} from 'react-map-gl';
 import {MapboxLayer} from '@deck.gl/mapbox';
 import {nearestEven} from '../../utils';
 import isEqual from 'lodash.isequal';
+import {DebugOverlay} from './DebugOverlay';
 
 export class Map extends Component {
   constructor(props) {
@@ -167,6 +168,16 @@ export class Map extends Component {
             />
           )}
         </DeckGL>
+        {debug && (
+          <DebugOverlay
+            deckRef={this.deckRef}
+            containerRef={this.containerRef}
+            dimension={dimension}
+            previewSize={previewSize}
+            dpi={dpi}
+            onDpiChange={this._changeDpi}
+          />
+        )}
       </div>
     );
   }

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -128,8 +128,10 @@ export class Map extends Component {
       setViewState,
       deckProps,
       staticMapProps,
-      dimension
+      dimension,
+      debug
     } = this.props;
+    const {glContext, dpi} = this.state;
     const deck = this.deckRef.current && this.deckRef.current.deck;
 
     const deckStyle = {
@@ -158,11 +160,11 @@ export class Map extends Component {
           height={dimension.height}
           {...adapter.getProps({deck, extraProps: deckProps})}
         >
-          {this.state.glContext && (
+          {glContext && (
             <StaticMap
               ref={this.mapRef}
               preventStyleDiffing={true}
-              gl={this.state.glContext}
+              gl={glContext}
               onLoad={this._onMapLoad}
               {...staticMapProps}
             />
@@ -173,7 +175,7 @@ export class Map extends Component {
             deckRef={this.deckRef}
             containerRef={this.containerRef}
             dimension={dimension}
-            previewSize={previewSize}
+            previewSize={{width, height}}
             dpi={dpi}
             onDpiChange={this._changeDpi}
           />

--- a/examples/worldview/src/features/map/MapContainer.js
+++ b/examples/worldview/src/features/map/MapContainer.js
@@ -28,7 +28,7 @@ import {dimensionSelector, adapterSelector} from '../renderer';
 import {updateViewState, viewStateSelector} from './mapSlice';
 import {updateTimeCursor} from '../timeline/timelineSlice';
 
-export const MapContainer = ({width = 540, height, deckProps, staticMapProps}) => {
+export const MapContainer = ({width = 540, height, deckProps, staticMapProps, debug}) => {
   const dispatch = useDispatch();
   const dimension = useSelector(dimensionSelector);
   const viewState = useSelector(viewStateSelector);
@@ -48,6 +48,7 @@ export const MapContainer = ({width = 540, height, deckProps, staticMapProps}) =
       adapter={adapter}
       dimension={dimension}
       updateTimeCursor={timeMs => dispatch(updateTimeCursor(timeMs))}
+      debug={debug}
     />
   );
 };

--- a/examples/worldview/src/features/monitor/MonitorPanel.js
+++ b/examples/worldview/src/features/monitor/MonitorPanel.js
@@ -177,6 +177,7 @@ export const MonitorPanel = ({deckProps = undefined, staticMapProps = undefined}
                 height={mapHeight}
                 deckProps={deckProps}
                 staticMapProps={staticMapProps}
+                debug={true}
               />
               <PrintViewState viewState={viewState} />
               <MapOverlay

--- a/examples/worldview/src/scenes/sftrees/index.js
+++ b/examples/worldview/src/scenes/sftrees/index.js
@@ -35,7 +35,7 @@ export const useScene = () => {
     // layerKeyframes: [],
     // tripKeyframe: {},
     cameraKeyframe: {
-      timings: [500, 3500],
+      timings: [500, 2500],
       keyframes: [SF, {...SF, pitch: 0, zoom: SF.zoom - 3}],
       easings: [easing.easeInOut]
     }
@@ -49,8 +49,15 @@ export const useScene = () => {
         framerate: 60
       })
     );
-    dispatch(resolutionChange('1920x1080'));
+    // dispatch(resolutionChange('1920x1080'));
     // dispatch(resolutionChange({width: 3840, height: 2160}));
+    // dispatch(resolutionChange({width: 5760, height: 5760}));
+    // dispatch(resolutionChange({width: 7680, height: 4320}));
+    // dispatch(resolutionChange({width: 1920, height: 1920}));
+    // dispatch(resolutionChange({width: 1080, height: 1920}));
+    // dispatch(resolutionChange({width: 1280, height: 720}));
+    dispatch(resolutionChange({width: 320, height: 180}));
+    // The maximum observed pixels supported are 33,177,600
     dispatch(
       formatConfigsChange({
         gif: {


### PR DESCRIPTION
Adding a `debug` prop to `Map` component when debugging resolutions. Related to #159

![Screen Shot 2021-10-05 at 10 58 26 AM](https://user-images.githubusercontent.com/2461547/136077504-047de758-6e36-4929-b153-0ec78d333e2c.png)
