### PR TITLE
add(worldview) Pillarbox component

### DIFF
--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -23,6 +23,7 @@ import DeckGL from '@deck.gl/react';
 import {StaticMap} from 'react-map-gl';
 import {MapboxLayer} from '@deck.gl/mapbox';
 import {nearestEven} from '../../utils';
+import {scale} from '../../utils';
 import isEqual from 'lodash.isequal';
 
 export class Map extends Component {
@@ -44,7 +45,8 @@ export class Map extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (!isEqual(prevProps.dimension, this.props.dimension)) {
+    const {dimension, previewSize} = this.props;
+    if (!isEqual(prevProps.dimension, dimension) || !isEqual(prevProps.previewSize, previewSize)) {
       this._resizeVideo();
     }
   }
@@ -122,8 +124,7 @@ export class Map extends Component {
     const {
       adapter,
       viewState,
-      width,
-      height,
+      previewSize,
       setViewState,
       deckProps,
       staticMapProps,
@@ -137,8 +138,8 @@ export class Map extends Component {
     };
 
     const containerStyle = {
-      width: `${width}px`,
-      height: `${height}px`,
+      width: `${previewSize.width}px`,
+      height: `${previewSize.height}px`,
       position: 'relative'
     };
 

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -23,7 +23,6 @@ import DeckGL from '@deck.gl/react';
 import {StaticMap} from 'react-map-gl';
 import {MapboxLayer} from '@deck.gl/mapbox';
 import {nearestEven} from '../../utils';
-import {scale} from '../../utils';
 import isEqual from 'lodash.isequal';
 import {DebugOverlay} from './DebugOverlay';
 
@@ -176,7 +175,7 @@ export class Map extends Component {
             deckRef={this.deckRef}
             containerRef={this.containerRef}
             dimension={dimension}
-            previewSize={{width, height}}
+            previewSize={previewSize}
           />
         )}
       </div>

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -57,8 +57,8 @@ export class Map extends Component {
   }
 
   _resizeVideo() {
-    const {width, dimension} = this.props;
-    this._setDevicePixelRatio(nearestEven(dimension.width / width));
+    const {previewSize, dimension} = this.props;
+    this._setDevicePixelRatio(nearestEven(dimension.width / previewSize.width));
     if (this.mapRef.current) {
       const map = this.mapRef.current.getMap();
       map.resize();

--- a/examples/worldview/src/features/map/MapContainer.js
+++ b/examples/worldview/src/features/map/MapContainer.js
@@ -28,7 +28,7 @@ import {dimensionSelector, adapterSelector} from '../renderer';
 import {updateViewState, viewStateSelector} from './mapSlice';
 import {updateTimeCursor} from '../timeline/timelineSlice';
 
-export const MapContainer = ({width = 540, height, deckProps, staticMapProps}) => {
+export const MapContainer = ({previewSize, deckProps, staticMapProps}) => {
   const dispatch = useDispatch();
   const dimension = useSelector(dimensionSelector);
   const viewState = useSelector(viewStateSelector);
@@ -39,8 +39,7 @@ export const MapContainer = ({width = 540, height, deckProps, staticMapProps}) =
       deckProps={deckProps}
       staticMapProps={staticMapProps}
       // UI Props
-      width={width}
-      height={height}
+      previewSize={previewSize}
       // Map Props
       viewState={viewState}
       setViewState={vs => dispatch(updateViewState(vs))}

--- a/examples/worldview/src/features/monitor/MonitorPanel.js
+++ b/examples/worldview/src/features/monitor/MonitorPanel.js
@@ -1,7 +1,6 @@
-import React, {useMemo, useCallback, useEffect} from 'react';
+import React, {useMemo, useEffect} from 'react';
 import {Play, Search, Maximize} from './Icons';
 import {useDispatch, useSelector} from 'react-redux';
-import styled from 'styled-components';
 import {
   busySelector,
   durationSelector,
@@ -10,13 +9,12 @@ import {
   useRenderHandler,
   seekTime
 } from '../renderer';
-import {AutoSizer} from 'react-virtualized';
 import {WithKeplerUI} from '@hubble.gl/react';
 import {Map, viewStateSelector} from '../map';
 import {CopyToClipboard} from 'react-copy-to-clipboard';
-import {nearestEven} from '../../utils';
 import {framestepSelector, timecodeSelector} from '../renderer/rendererSlice';
 import {timeCursorSelector} from '../timeline/timelineSlice';
+import {Pillarbox} from './Pillarbox';
 
 const MonitorBottomToolbar = ({playing, onPreview}) => {
   return (
@@ -50,7 +48,7 @@ function basicViewState(viewState = {}) {
 const PrintViewState = ({viewState}) => {
   const str = JSON.stringify(basicViewState(viewState));
   return (
-    <div style={{position: 'absolute', bottom: 0, left: 0, background: 'black'}}>
+    <div style={{background: 'black'}}>
       <CopyToClipboard text={str}>
         <div style={{color: 'pink'}}>{str}</div>
       </CopyToClipboard>
@@ -58,25 +56,18 @@ const PrintViewState = ({viewState}) => {
   );
 };
 
-const MapOverlay = ({rendererBusy, currentTime, duration, width, height}) => {
-  const loaderStyle = {
-    display: rendererBusy === 'rendering' ? 'flex' : 'none',
-    position: 'absolute',
-    background: 'rgba(0, 0, 0, 0.5)',
-    width: `${width}px`,
-    height: `${height}px`,
-    alignItems: 'center',
-    justifyContent: 'center'
-  };
+const RenderStatus = () => {
+  const duration = useSelector(durationSelector);
+  const timeCursor = useSelector(timeCursorSelector);
 
   const percent = useMemo(() => {
-    return Math.floor((currentTime / duration) * 100).toFixed(0);
-  }, [currentTime, duration]);
+    return Math.floor((timeCursor / duration) * 100).toFixed(0);
+  }, [timeCursor, duration]);
 
   return (
     <WithKeplerUI>
       {({LoadingSpinner}) => (
-        <div className="loader" style={loaderStyle}>
+        <div>
           <LoadingSpinner />
           <div
             className="rendering-percent"
@@ -89,44 +80,6 @@ const MapOverlay = ({rendererBusy, currentTime, duration, width, height}) => {
     </WithKeplerUI>
   );
 };
-
-const AutoSizeMapBox = ({children}) => {
-  const dimension = useSelector(dimensionSelector);
-
-  const getMapDimensions = useCallback(
-    (containerWidth, containerHeight) => {
-      const scale = Math.min(containerWidth / dimension.width, containerHeight / dimension.height);
-
-      return {
-        mapWidth: nearestEven(dimension.width * scale, 0),
-        mapHeight: nearestEven(dimension.height * scale, 0)
-      };
-    },
-    [dimension]
-  );
-
-  return (
-    <AutoSizer>
-      {({width, height}) => {
-        const {mapWidth, mapHeight} = getMapDimensions(width, height);
-        return children({
-          mapHeight,
-          mapWidth,
-          containerHeight: nearestEven(height, 0),
-          containerWidth: nearestEven(width, 0)
-        });
-      }}
-    </AutoSizer>
-  );
-};
-
-const MapBox = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: ${props => props.width}px;
-  height: ${props => props.height}px;
-`;
 
 const SeekSlider = () => {
   const timecode = useSelector(timecodeSelector);
@@ -149,9 +102,8 @@ const SeekSlider = () => {
 
 export const MonitorPanel = ({deckProps = undefined, staticMapProps = undefined}) => {
   const rendererBusy = useSelector(busySelector);
-  const duration = useSelector(durationSelector);
-  const timeCursor = useSelector(timeCursorSelector);
   const viewState = useSelector(viewStateSelector);
+  const dimension = useSelector(dimensionSelector);
   const onPreview = usePreviewHandler();
   const onRender = useRenderHandler();
 
@@ -168,28 +120,17 @@ export const MonitorPanel = ({deckProps = undefined, staticMapProps = undefined}
       }}
     >
       <div style={{flex: 1, position: 'relative'}}>
-        <AutoSizeMapBox>
-          {({mapHeight, mapWidth, containerHeight, containerWidth}) => (
-            <MapBox width={containerWidth} height={containerHeight}>
-              {/* <div style={{width: mapWidth, height: mapHeight, backgroundColor: 'green'}} /> */}
-              <Map
-                width={mapWidth}
-                height={mapHeight}
-                deckProps={deckProps}
-                staticMapProps={staticMapProps}
-              />
-              <PrintViewState viewState={viewState} />
-              <MapOverlay
-                rendererBusy={rendererBusy}
-                duration={duration}
-                width={containerWidth}
-                height={containerHeight}
-                currentTime={timeCursor}
-              />
-            </MapBox>
+        <Pillarbox dimension={dimension} overlay={rendererBusy === 'rendering' && <RenderStatus />}>
+          {previewSize => (
+            <Map
+              previewSize={previewSize}
+              deckProps={deckProps}
+              staticMapProps={staticMapProps}
+            />
           )}
-        </AutoSizeMapBox>
+        </Pillarbox>
       </div>
+      <PrintViewState viewState={viewState} />
       <MonitorBottomToolbar playing={Boolean(rendererBusy)} onPreview={onPreview} />
       <button onClick={onRender}>Render</button>
       <SeekSlider />

--- a/examples/worldview/src/features/monitor/Pillarbox.js
+++ b/examples/worldview/src/features/monitor/Pillarbox.js
@@ -1,0 +1,78 @@
+import React, {useCallback} from 'react';
+import styled from 'styled-components';
+import {AutoSizer} from 'react-virtualized';
+import {nearestEven, scale} from '../../utils';
+
+const AutoSizePillarbox = ({children, dimension}) => {
+  const getPreviewSize = useCallback(
+    ({width, height}) => {
+      const scalar = scale({width, height}, dimension);
+      return {
+        width: nearestEven(dimension.width * scalar, 0),
+        height: nearestEven(dimension.height * scalar, 0)
+      };
+    },
+    [dimension]
+  );
+
+  return (
+    <AutoSizer>
+      {({width, height}) => {
+        const previewSize = getPreviewSize({width, height});
+        return children({
+          previewSize,
+          pillarboxSize: {width: nearestEven(width, 0), height: nearestEven(height, 0)}
+        });
+      }}
+    </AutoSizer>
+  );
+};
+
+const PillarboxBackground = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: ${props => props.size.width}px;
+  height: ${props => props.size.height}px;
+`;
+
+const PillarboxOverlay = ({children, size}) => {
+  const overlayStyle = {
+    display: 'flex',
+    position: 'absolute',
+    background: 'rgba(0, 0, 0, 0.5)',
+    width: `${size.width}px`,
+    height: `${size.height}px`,
+    alignItems: 'center',
+    justifyContent: 'center'
+  };
+
+  return (
+    <div className="overlay" style={overlayStyle}>
+      {children}
+    </div>
+  );
+};
+
+export const Pillarbox = ({children, overlay, dimension}) => {
+  return (
+    <AutoSizePillarbox dimension={dimension}>
+      {({previewSize, pillarboxSize}) => (
+        <PillarboxBackground size={pillarboxSize}>
+          {children ? (
+            children(previewSize)
+          ) : (
+            <div
+              style={{
+                width: previewSize.width,
+                height: previewSize.height,
+                backgroundColor: 'green'
+              }}
+            />
+          )}
+          {overlay && <PillarboxOverlay size={pillarboxSize}>{overlay}</PillarboxOverlay>}
+        </PillarboxBackground>
+      )}
+    </AutoSizePillarbox>
+  );
+};

--- a/examples/worldview/src/utils.js
+++ b/examples/worldview/src/utils.js
@@ -4,3 +4,7 @@ export const nearestEven = (num, decimalPlaces = 3) => {
   num = 2 * Math.round(num / 2);
   return num / factorTen;
 };
+
+export function scale(startingSize, targetSize) {
+  return Math.min(startingSize.width / targetSize.width, startingSize.height / targetSize.height);
+}


### PR DESCRIPTION
**Context**
The pillarbox effect is the black bars placed on the sides of video when video aspect ratio doesn't match container ratio.

![image](https://user-images.githubusercontent.com/2461547/136080760-0361b2c9-e85b-4e8b-93de-b93907af7a03.png)

We already had this effect implemented so no visual changes are expected in this PR, but now they are refactored into their own module.

**Basic Usage**
```jsx
// The export resolution.
const dimension = { width: 1280, height: 720 }
// Overlay is optional.
const overlay = <div>Centered Overlay!</div>
{/* The available space for a preview in the UI. */}
<div style={{width: 1000, height: 1000}}>
  {/* Pillarbox grows to fill. */}
  <Pillarbox dimension={dimension} overlay={overlay}>
    {/* children are optional, a green box will render when undefined  */}
    {/* previewSize is "dimension" scaled to fit the space available while maintaining aspect ratio.  */}
    {previewSize => <div>{previewSize.width}px x {previewSize.height}px</div>}
  </Pillarbox>
</div>
```

**Examples**
Vertical
```jsx
<div style={{width: 1000, height: 2000}}>
  <Pillarbox dimension={dimension} />
</div>
```
![Screen Shot 2021-10-05 at 10 10 20 AM](https://user-images.githubusercontent.com/2461547/136080809-5208ba53-a93f-4a69-b8ba-cdb6188c5a42.png)
Wide
```jsx
<div style={{width: 2000, height: 1000}}>
  <Pillarbox dimension={dimension} />
</div>
```
![Screen Shot 2021-10-05 at 10 10 11 AM](https://user-images.githubusercontent.com/2461547/136080810-4594046d-4d5e-4e65-9a22-f3bb89fe6be9.png)