### PR TITLE
fix(worldview) only use _animate mode when rendering

### DIFF
--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -44,7 +44,7 @@ export default class DeckAdapter {
     this.animationManager = animationManager || new AnimationManager({});
     this.glContext = glContext;
     this.videoCapture = new VideoCapture();
-    this.shouldAnimate = true;
+    this.shouldAnimate = false;
     this.enabled = false;
     this.getProps = this.getProps.bind(this);
     this.render = this.render.bind(this);


### PR DESCRIPTION
**To Reproduce Bug**

1. Set deck.gl `_animate: true`. 
2. Resize the window or set a new dimension.
3. Notice all CSS rules passed to deck via `deckStyle` prop e.g. `transform: scale` do not update as expected, so the image goes off screen.

After review deck.gl code, `_animate` just forces `needsRedraw` to always return a reason, so `_drawLayers`  is always called (via `_customRender` in the react component). **Is there something in the deck.gl react component that prevents CSS style updates via `deckStyle` when `_animate: true`?**

**Before**
![Screen Shot 2021-10-05 at 3 26 25 PM](https://user-images.githubusercontent.com/2461547/136111736-32b87614-99c0-4713-bd35-d8643a80c380.png)

**After**
![Screen Shot 2021-10-05 at 3 27 03 PM](https://user-images.githubusercontent.com/2461547/136111751-49d4e15e-2343-4680-9b3a-569b02b583ec.png)
