### PR TITLE
add(react) useHubbleGl and useDeckAnimation hook

### DIFF
--- a/examples/camera/app.js
+++ b/examples/camera/app.js
@@ -1,9 +1,9 @@
-import React, {useState, useRef, useEffect, useMemo} from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 import DeckGL from '@deck.gl/react';
-import {useNextFrame, BasicControls, useDeckAdapter} from '@hubble.gl/react';
-import {animation} from './layers';
+import {useHubbleGl, BasicControls} from '@hubble.gl/react';
 import {vignette, fxaa} from '@luma.gl/shadertools';
 import {PostProcessEffect, MapView} from '@deck.gl/core';
+import {deckAnimation} from './layers';
 import {easing} from 'popmotion';
 
 const INITIAL_VIEW_STATE = {
@@ -77,20 +77,20 @@ const Container = ({children}) => (
 
 export default function App() {
   const deckRef = useRef(null);
-  const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
   const [busy, setBusy] = useState(false);
-  const {adapter, layers, cameraFrame, setCameraFrame} = useDeckAdapter(
-    animation,
-    INITIAL_VIEW_STATE
-  );
+
+  const {deckProps, adapter, cameraFrame, setCameraFrame} = useHubbleGl({
+    deckRef,
+    deckAnimation,
+    initialViewState: INITIAL_VIEW_STATE
+  });
+
   const [viewStateA, setViewStateA] = useState(cameraFrame);
   const [viewStateB, setViewStateB] = useState({
     ...cameraFrame,
     zoom: cameraFrame.zoom + 1,
     pitch: cameraFrame.pitch + 37
   });
-
-  const onNextFrame = useNextFrame();
 
   useEffect(() => {
     adapter.animationManager.setKeyframes('deck', {
@@ -126,8 +126,7 @@ export default function App() {
           effects={[vignetteEffect, aaEffect]}
           width={resolution.width}
           height={resolution.height}
-          layers={layers}
-          {...adapter.getProps({deck, onNextFrame})}
+          {...deckProps}
         />
       </div>
       <BasicControls

--- a/examples/camera/layers.js
+++ b/examples/camera/layers.js
@@ -81,7 +81,7 @@ function getLayers(animation) {
   ];
 }
 
-export const animation = new DeckAnimation({
+export const deckAnimation = new DeckAnimation({
   getLayers,
   layerKeyframes: [
     {

--- a/examples/quick-start/app.js
+++ b/examples/quick-start/app.js
@@ -1,6 +1,6 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 import {ScatterplotLayer, TextLayer} from '@deck.gl/layers';
-import {QuickAnimation, hold, DeckAnimation} from 'hubble.gl';
+import {QuickAnimation, hold, useDeckAnimation} from 'hubble.gl';
 import {easing} from 'popmotion';
 
 const INITIAL_VIEW_STATE = {
@@ -37,54 +37,50 @@ const Container = ({children}) => (
 );
 
 export default function App() {
-  const animation = useMemo(
-    () =>
-      new DeckAnimation({
-        getLayers: a =>
-          a.applyLayerKeyframes([
-            new ScatterplotLayer({
-              id: 'circle',
-              data: [{position: [-122.402, 37.79], color: [255, 0, 0], radius: 1000}],
-              getFillColor: d => d.color,
-              getRadius: d => d.radius,
-              opacity: 0.1,
-              radiusScale: 0.01
-            }),
-            new TextLayer({
-              id: 'text',
-              data: [{position: [-122.402, 37.79], text: 'Hello World'}],
-              opacity: 0.1,
-              getAngle: -90
-            })
-          ]),
-        layerKeyframes: [
-          {
-            id: 'circle',
-            keyframes: [
-              {opacity: 0.1, radiusScale: 0.01},
-              {opacity: 1, radiusScale: 1},
-              {opacity: 1, radiusScale: 1},
-              {opacity: 1, radiusScale: 20}
-            ],
-            timings: [0, 1000, 1500, 3000],
-            // https://popmotion.io/api/easing/
-            easings: [easing.anticipate, hold, easing.anticipate]
-          },
-          {
-            id: 'text',
-            keyframes: [
-              {opacity: 0, getAngle: -90},
-              {opacity: 1, getAngle: 0},
-              {opacity: 1, getAngle: 0},
-              {opacity: 0, getAngle: 0}
-            ],
-            timings: [0, 1000, 1500, 2000],
-            easings: [easing.reversed(easing.anticipate), hold, easing.easeIn]
-          }
-        ]
-      }),
-    []
-  );
+  const animation = useDeckAnimation({
+    getLayers: a =>
+      a.applyLayerKeyframes([
+        new ScatterplotLayer({
+          id: 'circle',
+          data: [{position: [-122.402, 37.79], color: [255, 0, 0], radius: 1000}],
+          getFillColor: d => d.color,
+          getRadius: d => d.radius,
+          opacity: 0.1,
+          radiusScale: 0.01
+        }),
+        new TextLayer({
+          id: 'text',
+          data: [{position: [-122.402, 37.79], text: 'Hello World'}],
+          opacity: 0.1,
+          getAngle: -90
+        })
+      ]),
+    layerKeyframes: [
+      {
+        id: 'circle',
+        keyframes: [
+          {opacity: 0.1, radiusScale: 0.01},
+          {opacity: 1, radiusScale: 1},
+          {opacity: 1, radiusScale: 1},
+          {opacity: 1, radiusScale: 20}
+        ],
+        timings: [0, 1000, 1500, 3000],
+        // https://popmotion.io/api/easing/
+        easings: [easing.anticipate, hold, easing.anticipate]
+      },
+      {
+        id: 'text',
+        keyframes: [
+          {opacity: 0, getAngle: -90},
+          {opacity: 1, getAngle: 0},
+          {opacity: 1, getAngle: 0},
+          {opacity: 0, getAngle: 0}
+        ],
+        timings: [0, 1000, 1500, 2000],
+        easings: [easing.reversed(easing.anticipate), hold, easing.easeIn]
+      }
+    ]
+  });
 
   return (
     <Container>

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -1,7 +1,7 @@
-import React, {useState, useRef, useMemo, useEffect} from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 import DeckGL from '@deck.gl/react';
 import {TerrainLayer} from '@deck.gl/geo-layers';
-import {useNextFrame, BasicControls, useDeckAdapter} from '@hubble.gl/react';
+import {BasicControls, useHubbleGl} from '@hubble.gl/react';
 import {hold, DeckAnimation} from '@hubble.gl/core';
 import {easing} from 'popmotion';
 
@@ -29,6 +29,7 @@ const ELEVATION_DECODER = {
 };
 
 const deckAnimation = new DeckAnimation({
+  // layers are dynamically defined with setGetLayers below.
   cameraKeyframe: {
     timings: [0, 6000, 7000, 8000, 14000],
     keyframes: [
@@ -138,16 +139,14 @@ const Container = ({children}) => (
 
 export default function App() {
   const deckRef = useRef(null);
-  const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
   const [busy, setBusy] = useState(false);
   const [rainbow, setRainbow] = useState(false);
 
-  const onNextFrame = useNextFrame();
-
-  const {adapter, layers, cameraFrame, setCameraFrame} = useDeckAdapter(
+  const {deckProps, adapter, cameraFrame, setCameraFrame} = useHubbleGl({
+    deckRef,
     deckAnimation,
-    INITIAL_VIEW_STATE
-  );
+    initialViewState: INITIAL_VIEW_STATE
+  });
 
   useEffect(() => {
     adapter.animationManager.getAnimation('deck').setGetLayers(animation => {
@@ -181,8 +180,7 @@ export default function App() {
           controller={false}
           width={resolution.width}
           height={resolution.height}
-          layers={layers}
-          {...adapter.getProps({deck, onNextFrame})}
+          {...deckProps}
         />
       </div>
       <BasicControls

--- a/examples/trips/app.js
+++ b/examples/trips/app.js
@@ -3,19 +3,15 @@
  * Source code: https://github.com/visgl/deck.gl/tree/master/examples/website/trips
  */
 
-import React, {useState, useRef, useEffect, useCallback, useMemo} from 'react';
+import React, {useState, useRef, useEffect, useCallback} from 'react';
 import DeckGL from '@deck.gl/react';
-import {DeckAnimation} from '@hubble.gl/core';
-import {useNextFrame, BasicControls, useDeckAdapter} from '@hubble.gl/react';
+import {BasicControls, useHubbleGl, useDeckAnimation} from '@hubble.gl/react';
 import {AmbientLight, PointLight, LightingEffect} from '@deck.gl/core';
 import {StaticMap} from 'react-map-gl';
 import {PolygonLayer} from '@deck.gl/layers';
 import {TripsLayer} from '@deck.gl/geo-layers';
 
 import {easing} from 'popmotion';
-
-import {MapboxLayer} from '@deck.gl/mapbox';
-import GL from '@luma.gl/constants';
 
 // Source data CSV
 const DATA_URL = {
@@ -116,67 +112,60 @@ const Container = ({children}) => (
 );
 
 export default function App({mapStyle = 'mapbox://styles/mapbox/dark-v9'}) {
-  const [glContext, setGLContext] = useState();
-
   const deckRef = useRef(null);
-  const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
-  const mapRef = useRef(null);
-
+  const staticMapRef = useRef(null);
   const [busy, setBusy] = useState(false);
-  const nextFrame = useNextFrame();
 
-  const animation = useMemo(
-    () =>
-      new DeckAnimation({
-        getLayers: a =>
-          a.applyLayerKeyframes([
-            new TripsLayer({
-              id: 'trips',
-              data: DATA_URL.TRIPS,
-              getPath: d => d.path,
-              getTimestamps: d => d.timestamps,
-              getColor: d =>
-                d.vendor === 0 ? DEFAULT_THEME.trailColor0 : DEFAULT_THEME.trailColor1,
-              opacity: 1,
-              widthMinPixels: 2,
-              rounded: true,
-              trailLength: 180,
-              shadowEnabled: false
-            }),
-            new PolygonLayer({
-              id: 'buildings',
-              data: DATA_URL.BUILDINGS,
-              extruded: true,
-              wireframe: false,
-              opacity: 0.5,
-              getPolygon: f => f.polygon,
-              getElevation: f => f.height,
-              getFillColor: DEFAULT_THEME.buildingColor,
-              material: DEFAULT_THEME.material
-            }),
-            new PolygonLayer({
-              id: 'ground',
-              data: landCover,
-              getPolygon: f => f,
-              stroked: false,
-              getFillColor: [0, 0, 0, 0]
-            })
-          ]),
-        layerKeyframes: [
-          {
-            id: 'trips',
-            timings: [0, timecode.end],
-            keyframes: [{currentTime: 0}, {currentTime: 1800}]
-          }
-        ]
-      }),
-    []
-  );
+  const deckAnimation = useDeckAnimation({
+    getLayers: a =>
+      a.applyLayerKeyframes([
+        new TripsLayer({
+          id: 'trips',
+          data: DATA_URL.TRIPS,
+          getPath: d => d.path,
+          getTimestamps: d => d.timestamps,
+          getColor: d => (d.vendor === 0 ? DEFAULT_THEME.trailColor0 : DEFAULT_THEME.trailColor1),
+          opacity: 1,
+          widthMinPixels: 2,
+          rounded: true,
+          trailLength: 180,
+          shadowEnabled: false
+        }),
+        new PolygonLayer({
+          id: 'buildings',
+          data: DATA_URL.BUILDINGS,
+          extruded: true,
+          wireframe: false,
+          opacity: 0.5,
+          getPolygon: f => f.polygon,
+          getElevation: f => f.height,
+          getFillColor: DEFAULT_THEME.buildingColor,
+          material: DEFAULT_THEME.material
+        }),
+        new PolygonLayer({
+          id: 'ground',
+          data: landCover,
+          getPolygon: f => f,
+          stroked: false,
+          getFillColor: [0, 0, 0, 0]
+        })
+      ]),
+    layerKeyframes: [
+      {
+        id: 'trips',
+        timings: [0, timecode.end],
+        keyframes: [{currentTime: 0}, {currentTime: 1800}]
+      }
+    ]
+  });
 
-  const {adapter, layers, cameraFrame, setCameraFrame} = useDeckAdapter(
-    animation,
-    INITIAL_VIEW_STATE
-  );
+  const {deckProps, staticMapProps, adapter, cameraFrame, setCameraFrame} = useHubbleGl({
+    deckRef,
+    staticMapRef,
+    deckAnimation,
+    initialViewState: INITIAL_VIEW_STATE
+  });
+
   const onViewStateChange = useCallback(
     ({viewState: vs}) => {
       adapter.animationManager.setKeyframes('deck', {
@@ -207,50 +196,26 @@ export default function App({mapStyle = 'mapbox://styles/mapbox/dark-v9'}) {
   );
   useEffect(() => onViewStateChange({viewState: cameraFrame}), []);
 
-  const onMapLoad = () => {
-    // const deck = deckRef.current.deck;
-    const map = mapRef.current.getMap();
-    // If there aren't any layers, combine map and deck with a fake layer.
-    if (!layers.length) {
-      map.addLayer(new MapboxLayer({id: '%%blank-layer', deck}));
-    }
-    for (let i = 0; i < layers.length; i++) {
-      // Adds DeckGL layers to Mapbox so Mapbox can be the bottom layer. Removing this clips DeckGL layers
-      map.addLayer(new MapboxLayer({id: layers[i].id, deck}));
-    }
-    map.on('render', () => adapter.onAfterRender(nextFrame));
-  };
-
   return (
     <Container>
       <div style={{position: 'relative'}}>
         <DeckGL
           ref={deckRef}
           style={{position: 'unset'}}
-          layers={layers}
           effects={DEFAULT_THEME.effects}
           controller={true}
           viewState={cameraFrame}
           onViewStateChange={onViewStateChange}
-          onWebGLInitialized={setGLContext}
-          parameters={{
-            depthTest: true,
-            // clearColor: [61 / 255, 20 / 255, 76 / 255, 1]
-            blend: true,
-            // blendEquation: GL.FUNC_ADD,
-            blendFunc: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA]
-          }}
           width={resolution.width}
           height={resolution.height}
-          {...adapter.getProps({deck})}
+          {...deckProps}
         >
-          {glContext && (
+          {staticMapProps.gl && (
             <StaticMap
-              ref={mapRef}
+              ref={staticMapRef}
               mapStyle={mapStyle}
               preventStyleDiffing={true}
-              gl={glContext}
-              onLoad={onMapLoad}
+              {...staticMapProps}
               // Note: 'reuseMap' prop with gatsby and mapbox extension causes stale reference error.
             />
           )}

--- a/examples/trips/app.js
+++ b/examples/trips/app.js
@@ -214,7 +214,6 @@ export default function App({mapStyle = 'mapbox://styles/mapbox/dark-v9'}) {
             <StaticMap
               ref={staticMapRef}
               mapStyle={mapStyle}
-              preventStyleDiffing={true}
               {...staticMapProps}
               // Note: 'reuseMap' prop with gatsby and mapbox extension causes stale reference error.
             />

--- a/modules/main/src/index.js
+++ b/modules/main/src/index.js
@@ -49,6 +49,8 @@ export {
 export {
   useNextFrame,
   useDeckAdapter,
+  useDeckAnimation,
+  useHubbleGl,
   BasicControls,
   EncoderDropdown,
   QuickAnimation

--- a/modules/react/src/hooks.js
+++ b/modules/react/src/hooks.js
@@ -100,7 +100,8 @@ export function useHubbleGl({
     onStaticMapLoad,
     staticMapProps: {
       gl: glContext,
-      onLoad: onStaticMapLoad
+      onLoad: onStaticMapLoad,
+      preventStyleDiffing: true
     },
     deckProps: adapter.getProps({
       deck,

--- a/modules/react/src/index.js
+++ b/modules/react/src/index.js
@@ -31,5 +31,5 @@ export {
   QuickAnimation,
   RenderPlayer
 } from './components';
-export {useNextFrame, useDeckAdapter} from './hooks';
+export {useNextFrame, useDeckAdapter, useDeckAnimation, useHubbleGl} from './hooks';
 export {createKeplerLayers} from './kepler-layers';


### PR DESCRIPTION
Use these hooks in react applications to reduce integration effort.

- Supports a deck.gl animation
- Optionally supports a base map for react-map-gl

```jsx
// minimal integration
import { useDeckAnimation, useHubbleGl} from '@hubble.gl/react';

const deckRef = useRef(null);
const staticMapRef = useRef(null); // optional base map

const deckAnimation = useDeckAnimation({
  getLayers: ...
  layerKeyframes: ...
  cameraKeyframe: ...
});

const {deckProps, staticMapProps, adapter, cameraFrame, setCameraFrame} = useHubbleGl({
    deckRef,
    staticMapRef,
    deckAnimation,
    initialViewState
});

<DeckGL
  ref={deckRef}
  viewState={cameraFrame}
  {/* add props before spreading hubble props */}
  {...deckProps}
>
  {/* optional base map */
  {staticMapProps.gl && (
    <StaticMap
      ref={staticMapRef}
      {/* add props before spreading hubble props */}
      {...staticMapProps}
    />
  )}
</DeckGL>
```