### PR TITLE
Fix montage render bug

### DIFF
--- a/examples/worldview/README.md
+++ b/examples/worldview/README.md
@@ -9,6 +9,7 @@ yarn
 ```
 
 #### 2. Mapbox Token
+
 Add mapbox access token to env.
 
 ```sh

--- a/examples/worldview/package.json
+++ b/examples/worldview/package.json
@@ -39,6 +39,6 @@
     "webpack-hot-middleware": "^2.24.3"
   },
   "resolutions": {
-    "mapbox-gl": "2.4.1"
+    "mapbox-gl": "2.5.1"
   }
 }

--- a/examples/worldview/src/app/App.js
+++ b/examples/worldview/src/app/App.js
@@ -33,7 +33,7 @@ import {MonitorPanel} from '../features/monitor/MonitorPanel';
 import {useKeplerDeckLayers, createSelectMapStyle} from '../features/kepler';
 
 // import {useScene} from '../scenes/newYork';
-import {useScene} from '../scenes/sftrees';
+import {useScene} from '../scenes/montage2';
 
 const GlobalStyle = styled.div`
   font-family: ff-clan-web-pro, 'Helvetica Neue', Helvetica, sans-serif;
@@ -77,14 +77,14 @@ const WindowSize = styled.div`
 
 const KEPLER_MAP_ID = 'map';
 const selectMapStyle = createSelectMapStyle(KEPLER_MAP_ID);
-const sceneLayers = [];
+let sceneLayers = [];
 const App = ({}) => {
-  useScene();
+  sceneLayers = useScene();
   const keplerDeckLayers = useKeplerDeckLayers(KEPLER_MAP_ID);
   const deckProps = useMemo(() => {
     return {
-      // layers: [...keplerDeckLayers, ...sceneLayers]
-      layers: [...sceneLayers, ...keplerDeckLayers]
+      layers: [...keplerDeckLayers, ...sceneLayers]
+      // layers: [...sceneLayers, ...keplerDeckLayers]
       // layers: []
       // layers: keplerDeckLayers
     };

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -179,7 +179,7 @@ export class Map extends Component {
     const deckStyle = {
       width: `${canvasClientSize.width}px`,
       height: `${canvasClientSize.height}px`,
-      transform: `scale(${scalar})`,
+      //   transform: `scale(${scalar})`,
       transformOrigin: 'top left'
     };
 

--- a/examples/worldview/src/features/map/MapContainer.js
+++ b/examples/worldview/src/features/map/MapContainer.js
@@ -48,7 +48,7 @@ export const MapContainer = ({previewSize, deckProps, staticMapProps, debug, vie
       resolution={resolution}
       updateTimeCursor={timeMs => dispatch(updateTimeCursor(timeMs))}
       debug={debug}
-      viewportMinAxis={viewportMinAxis}
+      viewportMinAxis={Math.min(resolution.width, resolution.height)}
     />
   );
 };


### PR DESCRIPTION
- Update `mapbox-gl` version to 2.5.1 to fix white border lines that appear sometimes when rendering an image due to rounding issue. Transform is disabled to mitigate a bug introduced by 2.5.1 which results in misalignment between layers
- viewportMinAxis is now set to minimum of resolution width and height
