### PR TITLE
Estimate file size with "Approx." rather than ~

### DIFF
--- a/modules/react/src/components/export-video/modal-tab-settings.js
+++ b/modules/react/src/components/export-video/modal-tab-settings.js
@@ -59,7 +59,7 @@ function SettingsTab({settings, resolution, disabled}) {
             />
             <StyledLabelCell>File Size</StyledLabelCell>
             <StyledValueCell>
-              ~
+              Approx.{' '}
               {estimateFileSize(
                 settings.frameRate,
                 resolution,


### PR DESCRIPTION
`~` can be misread in some fonts and situations as a negative number, so suggesting "Approx." instead.