### PR TITLE
fix(video-preview) don't call getMap when disableStaticMap is set

### DIFF
--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -116,7 +116,7 @@ export class ExportVideoPanelPreview extends Component {
   _onAfterRender() {
     this.props.adapter.onAfterRender(() => {
       this.forceUpdate();
-    }, this.mapRef.current.getMap().areTilesLoaded());
+    }, this.props.disableStaticMap || this.mapRef.current.getMap().areTilesLoaded());
   }
 
   _onMapLoad() {


### PR DESCRIPTION
Prevent crash when static map isn't used

- [x] don't call getMap when disableStaticMap is true