### PR TITLE
fix(ui) clamp min animation time

### DIFF
--- a/modules/react/src/components/export-video/modal-tab-animation.js
+++ b/modules/react/src/components/export-video/modal-tab-animation.js
@@ -26,6 +26,7 @@ function AnimationTab({settings, disabled}) {
                   showValues={false}
                   enableBarDrag={!disabled}
                   isRanged={false}
+                  value0={100}
                   value1={settings.durationMs}
                   step={100}
                   minValue={100}


### PR DESCRIPTION
Atm, it's possible to set animation time to 0, click on the preview button.
This causes an internal assertion crash which leaves the preview modal in a partially broken state.

- [x] clamp min animation time to 100ms. 