### PR TITLE
fix(video-export-panel): don't call onAfterRender after unmount

### DIFF
--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -59,6 +59,11 @@ export class ExportVideoPanelPreview extends Component {
   componentWillUnmount() {
     const {memoDevicePixelRatio} = this.state;
     this._setDevicePixelRatio(memoDevicePixelRatio);
+
+    if (this.mapRef.current) {
+      const map = this.mapRef.current.getMap();
+      map.off('render', this._onAfterRender);
+    }
   }
 
   _resizeVideo() {


### PR DESCRIPTION
- don't call onAfterRender after export-video-panel unmount.