### PR TITLE
enhance(capture) add support to skip processing a render, full abort.

### DIFF
--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -122,11 +122,12 @@ export default class DeckAdapter {
    * @param {() => void} params.onStopped
    * @param {(blob: Blob) => void} params.onSave
    * @param {() => void} params.onComplete
+   * @param {boolean} [params.abort]
    */
-  stop({onStopped, onSave, onComplete}) {
+  stop({onStopped, onSave, onComplete, abort}) {
     this.enabled = false;
     this.shouldAnimate = false;
-    this.videoCapture.stop({onStopped, onSave, onComplete});
+    this.videoCapture.stop({onStopped, onSave, onComplete, abort});
   }
 
   /**

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -302,9 +302,10 @@ export class ExportVideoPanelContainer extends Component {
     });
   }
 
-  onStop() {
+  onStop({abort = false}) {
     const {adapter} = this.state;
     adapter.stop({
+      abort,
       onStopped: () => this.setState({saving: true}),
       onComplete: () => {
         this.setState({
@@ -371,7 +372,10 @@ export class ExportVideoPanelContainer extends Component {
       <ExportVideoPanel
         // UI Props
         exportVideoWidth={exportVideoWidth}
-        handleClose={handleClose}
+        handleClose={() => {
+          this.onStop({abort: true});
+          handleClose();
+        }}
         header={header}
         // Map Props
         mapData={mapData}


### PR DESCRIPTION
Adds an `abort` option to the `stop` functions to override the default behavior of processing partial renders. When abort is true, the captured frames are fully discarded as if the render never started.