### PR TITLE
fix(examples) isolate builds and unpin deck.gl version

### DIFF
--- a/examples/get-started/pure-js/app.js
+++ b/examples/get-started/pure-js/app.js
@@ -177,7 +177,8 @@ printCamera();
 
 // update camera keyframes using buttons
 function filterCamera(viewState) {
-  const exclude = ['width', 'height', 'altitude'];
+  // TODO: we shouldn't need to exclude in application
+  const exclude = ['width', 'height', 'altitude', 'position', 'normalize'];
   return Object.keys(viewState)
     .filter(key => !exclude.includes(key))
     .reduce((obj, key) => {

--- a/examples/get-started/pure-js/package.json
+++ b/examples/get-started/pure-js/package.json
@@ -11,8 +11,9 @@
     "bootstrap": "yarn clean && yarn"
   },
   "dependencies": {
-    "@deck.gl/core": "8.2.0",
-    "@deck.gl/layers": "8.2.0"
+    "@hubble.gl/core": "^1.3.0",
+    "deck.gl": "^8.3.8",
+    "popmotion": "9.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.1",

--- a/examples/get-started/standalone/index.html
+++ b/examples/get-started/standalone/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
     <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.js'></script>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.css' rel='stylesheet' />
     <style>

--- a/examples/get-started/standalone/package.json
+++ b/examples/get-started/standalone/package.json
@@ -17,7 +17,9 @@
   },
   "main": "dist/hubblegl.min.js",
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --open"
+    "start-local": "webpack-dev-server --env.local --progress --open",
+    "clean": "rm -rf yarn.lock ./node_modules",
+    "bootstrap": "yarn clean && yarn"
   },
   "devDependencies": {
     "buble": "^0.19.3",

--- a/examples/kepler/index.html
+++ b/examples/kepler/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Hubble.gl in Kepler.gl</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {margin: 0; font-family: sans-serif; overflow: hidden;}
+    #app {width: 100vw; height: 100vh; display: flex; flex-direction: row; align-items: stretch;}
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+<script type="text/javascript" src="app.js"></script>
+<script type="text/javascript">
+  Root.renderToDOM(document.getElementById('app'));
+</script>
+</html>

--- a/examples/kepler/package.json
+++ b/examples/kepler/package.json
@@ -4,19 +4,23 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open",
     "start-local-luma": "webpack-dev-server --env.local --env.local-luma --progress --hot --open",
     "clean": "rm -rf yarn.lock ./node_modules",
-    "bootstrap": "yarn clean && yarn"
-  },
-  "peerDependencies": {
-    "@luma.gl/debug": "^8.2.0"
+    "bootstrap": "yarn clean && yarn",
+    "build": "rm -rf dist && mkdir dist && cp index.html dist/ && webpack --env.production=true"
   },
   "dependencies": {
+    "deck.gl": "8.2.0",
     "d3-request": "^1.0.6",
     "global": "^4.3.0",
+    "hubble.gl": "^1.3.0",
+    "kepler.gl": "^2.5.5",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "react-map-gl": "^5.2.10",
     "react-markdown": "^4.2.2",
     "react-palm": "^3.3.6",
     "redux-actions": "^2.2.1",
-    "redux-thunk": "^1.0.0"
+    "redux-thunk": "^1.0.0",
+    "react-intl": "^3.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.1",
@@ -28,5 +32,15 @@
     "webpack-dev-middleware": "^3.5.1",
     "webpack-dev-server": "^3.1.14",
     "webpack-hot-middleware": "^2.24.3"
+  },
+  "resolutions_comments": [
+    "deck.gl: pinned to 8.2.0 for compatibility with kepler.gl"
+  ],
+  "resolutions": {
+    "deck.gl": "8.2.0",
+    "@luma.gl/constants": "8.2.0",
+    "@luma.gl/core": "8.2.0",
+    "@luma.gl/shadertools": "8.2.0",
+    "@luma.gl/experimental": "8.2.0"
   }
 }

--- a/examples/kepler/src/main.js
+++ b/examples/kepler/src/main.js
@@ -19,18 +19,17 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import document from 'global/document';
 import {Provider} from 'react-redux';
 import {render} from 'react-dom';
 import store from './store';
 import App from './app';
 
-const Root = () => (
+export const Root = () => (
   <Provider store={store}>
-    <div style={{height: '100vh', width: '100vw'}}>
-      <App />
-    </div>
+    <App />
   </Provider>
 );
 
-render(<Root />, document.body.appendChild(document.createElement('div')));
+export function renderToDOM(container) {
+  render(<Root />, container);
+}

--- a/examples/kepler/webpack.config.js
+++ b/examples/kepler/webpack.config.js
@@ -1,4 +1,3 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 const resolve = require('path').resolve;
 
@@ -8,10 +7,9 @@ const CONFIG = {
   entry: {
     app: resolve('./src/main.js')
   },
+
   output: {
-    path: resolve(__dirname, 'build'),
-    filename: 'bundle.js',
-    publicPath: '/'
+    library: 'Root'
   },
 
   devtool: 'source-map',
@@ -32,7 +30,6 @@ const CONFIG = {
   },
 
   plugins: [
-    new HtmlWebpackPlugin({title: 'hubble.gl kepler export example'}),
     // Optional: Enables reading mapbox token from environment variable
     new webpack.EnvironmentPlugin(['MapboxAccessToken'])
   ]

--- a/examples/website/basic-basemap/app.js
+++ b/examples/website/basic-basemap/app.js
@@ -79,7 +79,8 @@ const Container = ({children}) => (
       width: '100%',
       height: '100%',
       position: 'relative',
-      backgroundColor: '#11183c'
+      backgroundColor: '#11183c',
+      overflow: 'hidden'
     }}
   >
     {children}

--- a/examples/website/basic-basemap/package.json
+++ b/examples/website/basic-basemap/package.json
@@ -6,13 +6,14 @@
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },
-  "peerDependencies": {
-    "@luma.gl/debug": "^8.2.0",
-    "@luma.gl/shadertools": "^8.2.0"
-  },
   "dependencies": {
+    "deck.gl": "^8.3.8",
+    "hubble.gl": "^1.3.0",
     "d3-color": "^1.4.1",
-    "react-map-gl": "^5.0.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "react-map-gl": "^5.0.0",
+    "popmotion": "9.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.1",
@@ -24,7 +25,10 @@
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.11"
   },
+  "resolutions_comments": [
+    "mapbox-gl: pinned to v1 for open license"
+  ],
   "resolutions": {
-    "mapbox-gl": "2.4.1"
+    "mapbox-gl": "^1.13.0"
   }
 }

--- a/examples/website/camera/app.js
+++ b/examples/website/camera/app.js
@@ -50,7 +50,8 @@ const aaEffect = new PostProcessEffect(fxaa, {});
 const vignetteEffect = new PostProcessEffect(vignette, {});
 
 function filterCamera(viewState) {
-  const exclude = ['width', 'height', 'altitude'];
+  // TODO: we shouldn't need to exclude in application
+  const exclude = ['width', 'height', 'altitude', 'position', 'normalize'];
   return Object.keys(viewState)
     .filter(key => !exclude.includes(key))
     .reduce((obj, key) => {
@@ -68,7 +69,8 @@ const Container = ({children}) => (
       width: '100%',
       height: '100%',
       position: 'relative',
-      backgroundColor: '#11183c'
+      backgroundColor: '#11183c',
+      overflow: 'hidden'
     }}
   >
     {children}

--- a/examples/website/camera/package.json
+++ b/examples/website/camera/package.json
@@ -6,11 +6,13 @@
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },
-  "peerDependencies": {
-    "@luma.gl/debug": "^8.2.0"
-  },
   "dependencies": {
-    "d3-color": "^1.4.1"
+    "d3-color": "^1.4.1",
+    "hubble.gl": "^1.3.0",
+    "deck.gl": "^8.3.8",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "popmotion": "9.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.1",

--- a/examples/website/quick-start/app.js
+++ b/examples/website/quick-start/app.js
@@ -29,7 +29,8 @@ const Container = ({children}) => (
       width: '100%',
       height: '100%',
       position: 'relative',
-      backgroundColor: '#11183c'
+      backgroundColor: '#11183c',
+      overflow: 'hidden'
     }}
   >
     {children}

--- a/examples/website/quick-start/package.json
+++ b/examples/website/quick-start/package.json
@@ -6,11 +6,13 @@
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },
-  "peerDependencies": {
-    "@luma.gl/debug": "^8.2.0"
-  },
   "dependencies": {
-    "d3-color": "^1.4.1"
+    "d3-color": "^1.4.1",
+    "hubble.gl": "^1.3.0",
+    "deck.gl": "^8.3.8",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "popmotion": "9.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.1",

--- a/examples/website/terrain/app.js
+++ b/examples/website/terrain/app.js
@@ -130,7 +130,8 @@ const Container = ({children}) => (
       width: '100%',
       height: '100%',
       position: 'relative',
-      backgroundColor: '#11183c'
+      backgroundColor: '#11183c',
+      overflow: 'hidden'
     }}
   >
     {children}

--- a/examples/website/terrain/package.json
+++ b/examples/website/terrain/package.json
@@ -7,6 +7,11 @@
     "bootstrap": "yarn clean && yarn"
   },
   "dependencies": {
+    "hubble.gl": "^1.3.0",
+    "deck.gl": "^8.3.8",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "popmotion": "9.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.1",

--- a/examples/website/trips/app.js
+++ b/examples/website/trips/app.js
@@ -105,7 +105,8 @@ const Container = ({children}) => (
       width: '100%',
       height: '100%',
       position: 'relative',
-      backgroundColor: '#11183c'
+      backgroundColor: '#11183c',
+      overflow: 'hidden'
     }}
   >
     {children}

--- a/examples/website/trips/package.json
+++ b/examples/website/trips/package.json
@@ -6,13 +6,14 @@
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },
-  "peerDependencies": {
-    "@luma.gl/debug": "^8.2.0",
-    "@luma.gl/shadertools": "^8.2.0"
-  },
   "dependencies": {
     "d3-color": "^1.4.1",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "^5.0.0",
+    "hubble.gl": "^1.3.0",
+    "deck.gl": "^8.3.8",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "popmotion": "9.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.1",
@@ -24,7 +25,10 @@
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.11"
   },
+  "resolutions_comments": [
+    "mapbox-gl: pinned to v1 for open license"
+  ],
   "resolutions": {
-    "mapbox-gl": "2.4.1"
+    "mapbox-gl": "^1.13.0"
   }
 }

--- a/examples/worldview/package.json
+++ b/examples/worldview/package.json
@@ -6,24 +6,25 @@
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },
-  "peerDependencies": {
-    "@luma.gl/debug": "^8.2.0"
-  },
   "dependencies": {
+    "deck.gl": "8.2.0",
     "@loaders.gl/core": "^2.3.13",
     "@loaders.gl/json": "^2.3.13",
-    "@loaders.gl/csv": "^2.3.13",
     "@reduxjs/toolkit": "^1.5.0",
     "d3-request": "^1.0.6",
     "global": "^4.3.0",
+    "hubble.gl": "^1.3.0",
     "lodash.isequal": "^4.5.0",
+    "kepler.gl": "^2.5.5",
     "react-copy-to-clipboard": "^5.0.3",
     "react-helmet": "^6.1.0",
     "react-map-gl": "^6.1.15",
     "react-markdown": "^4.2.2",
     "react-palm": "^3.3.6",
     "redux-actions": "^2.2.1",
-    "redux-thunk": "^1.0.0"
+    "redux-thunk": "^1.0.0",
+    "react-intl": "^3.12.0",
+    "popmotion": "9.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.1",
@@ -37,7 +38,16 @@
     "webpack-dev-server": "^3.1.14",
     "webpack-hot-middleware": "^2.24.3"
   },
+  "resolutions_comments": [
+    "deck.gl: pinned to 8.2.0 for compatibility with kepler.gl",
+    "mapbox-gl: pinned to v1 for open license"
+  ],
   "resolutions": {
-    "mapbox-gl": "2.4.1"
+    "deck.gl": "8.2.0",
+    "@luma.gl/constants": "8.2.0",
+    "@luma.gl/core": "8.2.0",
+    "@luma.gl/shadertools": "8.2.0",
+    "@luma.gl/experimental": "8.2.0",
+    "mapbox-gl": "^1.13.0"
   }
 }


### PR DESCRIPTION
- removing deck.gl 8.2.0 pin
- pinning mapbox v1 in examples for open license
- example builds are isolated and can be copied to their own environment