### PR TITLE
[react] MapboxOverlay-ready hooks and `basic-basemap` example

### DIFF
--- a/examples/website/basic-basemap/package.json
+++ b/examples/website/basic-basemap/package.json
@@ -10,20 +10,15 @@
   },
   "dependencies": {
     "deck.gl": "^8.9",
-    "hubble.gl": "^1.3.0",
+    "hubble.gl": "^1.4.0-alpha.0",
     "d3-color": "^1.4.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "react-map-gl": "^5.0.0",
+    "react-map-gl": "^7.1.8",
+    "maplibre-gl": "^3.6.2",
     "popmotion": "9.3.1"
   },
   "devDependencies": {
     "vite": "^4.0.0"
-  },
-  "resolutions_comments": [
-    "mapbox-gl: pinned to v1 for open license"
-  ],
-  "resolutions": {
-    "mapbox-gl": "^1.13.0"
   }
 }

--- a/examples/website/basic-basemap/set-ref.ts
+++ b/examples/website/basic-basemap/set-ref.ts
@@ -1,0 +1,11 @@
+import type {ForwardedRef} from 'react';
+
+// Helper for covering all of the typescript cases for setting a ref
+export function setRef<T>(ref: ForwardedRef<T>, value: T) {
+  if (!ref) return;
+  if (typeof ref === 'function') {
+    ref(value);
+  } else {
+    ref.current = value;
+  }
+}

--- a/examples/website/basic-basemap/vite.config.js
+++ b/examples/website/basic-basemap/vite.config.js
@@ -1,5 +1,0 @@
-export default {
-  define: {
-    'process.env.MapboxAccessToken': JSON.stringify(process.env.MapboxAccessToken)
-  }
-};


### PR DESCRIPTION
### Changelog

- removes deprecated `MapboxLayer`
- switches `basic-basemap` example to maplibre
- demonstrates using `@deck.gl/mapbox`'s `MapboxOverlay` instead of `@deck.gl/react`'s `DeckGL` for rendering deck in a basemap context
- update readme example