### PR TITLE
chore(main) add top-level import test

### DIFF
--- a/modules/main/src/index.ts
+++ b/modules/main/src/index.ts
@@ -3,9 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 export {
+  VERSION,
   // Adapter
   DeckAdapter,
   // Encoders
+  GifEncoder,
   PNGSequenceEncoder,
   JPEGSequenceEncoder,
   JPEGEncoder,
@@ -37,5 +39,14 @@ export {
   useHubbleGl,
   BasicControls,
   EncoderDropdown,
-  QuickAnimation
+  QuickAnimation,
+  ExportVideoModal,
+  ExportVideoPanelContainer,
+  InjectKeplerUI,
+  KeplerUIContext,
+  RenderPlayer,
+  ResolutionGuide,
+  WithKeplerUI,
+  createKeplerLayers,
+  injectKeplerUI
 } from '@hubble.gl/react';

--- a/test/imports-spec.ts
+++ b/test/imports-spec.ts
@@ -1,0 +1,50 @@
+// hubble.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+
+import * as hubble from 'hubble.gl';
+import * as core from '@hubble.gl/core';
+import * as react from '@hubble.gl/react';
+
+test('Top-level imports', t0 => {
+  const hasEmptyExports = obj => {
+    for (const key in obj) {
+      if (obj[key] === undefined) {
+        return key;
+      }
+    }
+    return false;
+  };
+
+  t0.test('import "hubble.gl"', t => {
+    t.notOk(hasEmptyExports(hubble), 'No empty top-level export in hubble.gl');
+    t.notOk(hasEmptyExports(core), 'No empty top-level export in @hubble.gl/core');
+    t.notOk(hasEmptyExports(react), 'No empty top-level export in @hubble.gl/react');
+    t.end();
+  });
+
+  t0.end();
+});
+
+test('hubble.gl re-exports', t => {
+  const findMissingExports = (source, target) => {
+    const missingExports = [];
+    for (const key in source) {
+      // Exclude experimental exports
+      if (key[0] !== '_' && key !== 'experimental' && target[key] !== source[key]) {
+        missingExports.push(key);
+      }
+    }
+    return missingExports.length ? missingExports : null;
+  };
+
+  t.notOk(findMissingExports(core, hubble), 'hubble.gl re-exports everything from @hubble.gl/core');
+  t.notOk(
+    findMissingExports(react, hubble),
+    'hubble.gl re-exports everything from @hubble.gl/react'
+  );
+
+  t.end();
+});

--- a/test/modules.ts
+++ b/test/modules.ts
@@ -1,6 +1,7 @@
 // hubble.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
+import './imports-spec';
 import '../modules/core/test/index';
 import '../modules/main/test/index';
 import '../modules/react/test/index';

--- a/test/node.ts
+++ b/test/node.ts
@@ -22,4 +22,4 @@ _global.HTMLVideoElement = dom.window.HTMLVideoElement;
 _global.requestAnimationFrame = cb => setTimeout(cb, 0);
 _global.cancelAnimationFrame = t => clearTimeout(t);
 
-import './modules';
+// import './imports-spec';


### PR DESCRIPTION
- Adding a top-level import test to ensure that all of the hubble.gl modules are correctly exported.
  - Added missing exports to the main package.
- Node tests fail to import deck.gl's typed modules, so they've been disabled. Hopefully this issue is resolved with the v9 upgrade.