### PR TITLE
fix(website) remove pre-push to fix website action

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "jsdom": "^20.0.0",
     "ocular-dev-tools": "2.0.0-alpha.33",
     "pre-commit": "^1.2.2",
-    "pre-push": "^0.1.1",
     "puppeteer": "24.2.0",
     "tap-spec": "^5.0.0",
     "tape-catch": "^1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7934,7 +7934,6 @@ __metadata:
     jsdom: "npm:^20.0.0"
     ocular-dev-tools: "npm:2.0.0-alpha.33"
     pre-commit: "npm:^1.2.2"
-    pre-push: "npm:^0.1.1"
     puppeteer: "npm:24.2.0"
     tap-spec: "npm:^5.0.0"
     tape-catch: "npm:^1.0.6"
@@ -11200,17 +11199,6 @@ __metadata:
     spawn-sync: "npm:^1.0.15"
     which: "npm:1.2.x"
   checksum: 10c0/879e57445ce6ce821f1e5eaf7c2f449912ca337b431c4fbd4d167cbf8d5040de87930db4c2ca583e1c4abcb525f53b220d9b0686dc3b548d7563067a7a8ad5bb
-  languageName: node
-  linkType: hard
-
-"pre-push@npm:^0.1.1":
-  version: 0.1.3
-  resolution: "pre-push@npm:0.1.3"
-  dependencies:
-    cross-spawn: "npm:^5.0.1"
-    spawn-sync: "npm:^1.0.15"
-    which: "npm:1.2.x"
-  checksum: 10c0/ef513d1e91a1b0c8004dae5c3ca3521ea1ea1bf4a10596e82d459cf775e7839d4fa30770a0083f36a45ca671db588e17ab66801d2682cd90b38c2940b93b5e66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`node_modules` is removed during website action, meaning `pre-push` doesn't exist and git crashes during push.

Here's an example of the error: https://github.com/visgl/hubble.gl/actions/runs/13193591312

![Screenshot 2025-02-07 at 11 02 33 AM](https://github.com/user-attachments/assets/47215986-eff7-44f7-9556-0cd688c6e795)

We don't need pre-push since pre-commit does the same thing, and we have CI. This PR removes it.