### PR TITLE
Only run browser tests on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: yarn build
 
       - name: Run tests from transpiled code
-        run: npx ocular-test dist
+        run: yarn test browser-headless dist
 
       - name: Login to NPM
         run: npm config set "//registry.npmjs.org/:_authToken=${NPM_ACCESS_TOKEN}"


### PR DESCRIPTION
Released [failed](https://github.com/visgl/hubble.gl/actions/runs/13979754983/job/39142195898) since [distribution tests](https://github.com/visgl/dev-tools/blob/ef50bfbaed323174b37148a4716b7894069d5404/modules/dev-tools/scripts/test.sh#L56-L58C28) both node and browser.