### PR TITLE
fix: view clearColor for non-transparent backgrounds

### DIFF
--- a/examples/get-started/pure-js/app.js
+++ b/examples/get-started/pure-js/app.js
@@ -83,10 +83,7 @@ export const deck = new Deck({
   },
   controller: true,
   views: new MapView({
-    // most video formats don't fully support transparency
-    clear: {
-      color: [255, 255, 255, 1]
-    }
+    clearColor: [255, 255, 255, 1]
   }),
   layers: [
     new GeoJsonLayer({

--- a/examples/get-started/pure-js/package.json
+++ b/examples/get-started/pure-js/package.json
@@ -9,7 +9,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@hubble.gl/core": "^1.4.0",
+    "@hubble.gl/core": "^2.0.0-alpha.3",
     "deck.gl": "^9.1",
     "popmotion": "9.3.1"
   },

--- a/examples/get-started/scripting/index.html
+++ b/examples/get-started/scripting/index.html
@@ -2,10 +2,19 @@
   <head>
     <!-- deck.gl standalone bundle -->
     <script src="https://unpkg.com/deck.gl@9.1/dist.min.js"></script>
-    <script src="https://unpkg.com/hubble.gl@1.4.0/dist.min.js"></script>
+    <script src="https://unpkg.com/hubble.gl@2.0.0-alpha.3/dist.min.js"></script>
     <style>
-      body {margin: 0; padding: 0; font-family: Helvetica, Arial, sans-serif;}
-      #geo, #non-geo {position: absolute; width: 50vw; height: 50vh;}
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: Helvetica, Arial, sans-serif;
+      }
+      #geo,
+      #non-geo {
+        position: absolute;
+        width: 50vw;
+        height: 50vh;
+      }
       /* #non-geo {left: 50vw; top: 0;} */
       .render-result {
         position: absolute;
@@ -109,9 +118,7 @@
       mapbox: false /* disable map */,
       views: new deck.OrbitView({
         // most video formats don't fully support transparency
-        clear: {
-          color: [255, 255, 255, 1]
-        }
+        clearColor: [255, 255, 255, 1]
       }),
       initialViewState: {distance: 1, fov: 50, rotationX: 10, rotationOrbit: 160, zoom: 3.5},
       controller: false,

--- a/examples/kepler/package.json
+++ b/examples/kepler/package.json
@@ -5,19 +5,19 @@
     "build": "vite build"
   },
   "dependencies": {
-    "deck.gl": "8.9.27",
     "d3-request": "^1.0.6",
+    "deck.gl": "8.9.27",
     "global": "^4.3.0",
-    "hubble.gl": "^1.4.0",
+    "hubble.gl": "^2.0.0-alpha.3",
     "kepler.gl": "3.1.0",
     "mapbox-gl": "1.13.1",
     "maplibre-gl": "^3.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intl": "^6.8.9",
     "react-map-gl": "^7.1.8",
     "react-markdown": "^6.0.3",
     "redux-thunk": "^1.0.0",
-    "react-intl": "^6.8.9",
     "styled-components": "6.1.8"
   },
   "devDependencies": {
@@ -32,7 +32,7 @@
     "@luma.gl/core": "8.5.21",
     "@luma.gl/shadertools": "8.5.21",
     "@luma.gl/experimental": "8.5.21",
-    "@hubble.gl/core": "1.4.0",
-    "@hubble.gl/react": "1.4.0"
+    "@hubble.gl/core": "2.0.0-alpha.3",
+    "@hubble.gl/react": "2.0.0-alpha.3"
   }
 }

--- a/examples/website/basic-basemap-mapbox-legacy/package.json
+++ b/examples/website/basic-basemap-mapbox-legacy/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "deck.gl": "^8.9",
-    "hubble.gl": "^1.4.0",
+    "hubble.gl": "^2.0.0-alpha.3",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-map-gl": "^7.1.8",

--- a/examples/website/basic-basemap-mapbox/package.json
+++ b/examples/website/basic-basemap-mapbox/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "deck.gl": "^9.1",
-    "hubble.gl": "^1.4.0",
+    "hubble.gl": "^2.0.0-alpha.3",
     "mapbox-gl": "^3.10.0",
     "popmotion": "9.3.1",
     "react": "^18.3.0",

--- a/examples/website/basic-basemap/package.json
+++ b/examples/website/basic-basemap/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "deck.gl": "^9.1",
-    "hubble.gl": "^1.4.0",
+    "hubble.gl": "^2.0.0-alpha.3",
     "maplibre-gl": "^3.6.2",
     "popmotion": "9.3.1",
     "react": "^18.3.0",

--- a/examples/website/camera/app.jsx
+++ b/examples/website/camera/app.jsx
@@ -113,9 +113,7 @@ export default function App() {
           views={
             new MapView({
               farZMultiplier: 3,
-              clear: {
-                color: [61 / 255, 20 / 255, 76 / 255, 1]
-              }
+              clearColor: [255, 255, 255, 1]
             })
           }
           parameters={{

--- a/examples/website/camera/package.json
+++ b/examples/website/camera/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@luma.gl/effects": "9.1.4",
     "deck.gl": "^9.1",
-    "hubble.gl": "^1.4.0",
+    "hubble.gl": "^2.0.0-alpha.3",
     "popmotion": "9.3.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"

--- a/examples/website/quick-start/app.jsx
+++ b/examples/website/quick-start/app.jsx
@@ -93,10 +93,7 @@ export default function App() {
         animation={animation}
         deckProps={{
           views: new MapView({
-            // most video formats don't fully support transparency
-            clear: {
-              color: [255, 255, 255, 1]
-            }
+            clearColor: [255, 255, 255, 1]
           })
         }}
         timecode={TIMECODE}

--- a/examples/website/quick-start/package.json
+++ b/examples/website/quick-start/package.json
@@ -9,8 +9,8 @@
     "build": "vite build"
   },
   "dependencies": {
-    "deck.gl": "^8.9",
-    "hubble.gl": "^1.4.0",
+    "deck.gl": "^9.1",
+    "hubble.gl": "^2.0.0-alpha.3",
     "popmotion": "9.3.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"

--- a/examples/website/quick-start/quick-start-after.jsx
+++ b/examples/website/quick-start/quick-start-after.jsx
@@ -78,10 +78,7 @@ export default function App() {
       animation={animation}
       deckProps={{
         views: new MapView({
-          // most video formats don't fully support transparency
-          clear: {
-            color: [255, 255, 255, 1]
-          }
+          clearColor: [255, 255, 255, 1]
         })
       }}
       timecode={TIMECODE}

--- a/examples/website/quick-start/quick-start-before.jsx
+++ b/examples/website/quick-start/quick-start-before.jsx
@@ -33,12 +33,11 @@ export default function App() {
       width={640}
       height={480}
       layers={layers}
-      views={new MapView({
-        // most video formats don't fully support transparency
-        clear: {
-          color: [255, 255, 255, 1]
-        }
-      })}
+      views={
+        new MapView({
+          clearColor: [255, 255, 255, 1]
+        })
+      }
     />
   );
 }

--- a/examples/website/terrain/package.json
+++ b/examples/website/terrain/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "deck.gl": "^9.1",
-    "hubble.gl": "^1.4.0",
+    "hubble.gl": "^2.0.0-alpha.3",
     "popmotion": "9.3.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"

--- a/examples/website/trips/package.json
+++ b/examples/website/trips/package.json
@@ -9,13 +9,13 @@
     "build": "vite build"
   },
   "dependencies": {
-    "react-map-gl": "^8.0.1",
-    "hubble.gl": "^1.4.0",
-    "maplibre-gl": "^3.6.2",
     "deck.gl": "^9.1",
+    "hubble.gl": "^2.0.0-alpha.3",
+    "maplibre-gl": "^3.6.2",
+    "popmotion": "9.3.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "popmotion": "9.3.1"
+    "react-map-gl": "^8.0.1"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -58,7 +58,7 @@
     "@deck.gl/mapbox": ">=9.1.0",
     "@deck.gl/react": ">=9.1.0",
     "@deck.gl/widgets": ">=9.1.0",
-    "@hubble.gl/core": "1.4.0",
+    "@hubble.gl/core": "^2.0.0-alpha.3",
     "@loaders.gl/core": "^4.3.3",
     "mapbox-gl": ">=1.13.1",
     "react": ">=18.2",

--- a/test/apps/standalone/index.js
+++ b/test/apps/standalone/index.js
@@ -70,9 +70,7 @@ const nonGeoExample = new deck.DeckGL({
   mapbox: false /* disable map */,
   views: new deck.OrbitView({
     // most video formats don't fully support transparency
-    clear: {
-      color: [255, 255, 255, 1]
-    }
+    clearColor: [255, 255, 255, 1]
   }),
   initialViewState: {distance: 1, fov: 50, rotationX: 10, rotationOrbit: 160, zoom: 3.5},
   controller: false,


### PR DESCRIPTION
Depends on: https://github.com/visgl/deck.gl/discussions/8808, https://github.com/visgl/deck.gl/issues/8838 to properly work.

Assumes [Option 2](https://github.com/visgl/deck.gl/issues/8838#:~:text=Option%202,%7D%3B%0A%7D) is implemented.

Added separate from #325 to accelerate the release of 2.0.0-alpha.4 while the dependent issues are fixed.